### PR TITLE
Remove on-push workflows

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -3,8 +3,6 @@ name: Benchmarks
 on:
   pull_request:
     branches: ["main"]
-  push:
-    branches: ["main"]
 
 jobs:
   benchmark:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -3,8 +3,6 @@ name: CI
 on:
   pull_request:
     branches: ["main"]
-  push:
-    branches: ["main"]
 
 jobs:
   check:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -239,7 +239,7 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "finders"
-version = "2.1.0"
+version = "2.1.1"
 dependencies = [
  "clap",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "finders"
-version = "2.1.0"
+version = "2.1.1"
 edition = "2024"
 authors = ["Youcef Kadri <youcef.d.kadri@gmail.com>"]
 readme = "README.md"


### PR DESCRIPTION
### Summary
<!-- A summary of changes in this PR (e.g. "Allow excluding strings in search") -->
Remove `push: main` from workflow triggers

### Reasoning
<!-- Why was this change needed? Link to issues if needs be -->
These are unnecessary as we have branch-protection rules preventing direct pushes to the main branch.

### Changes
<!-- A more detailed list of changes, including affected functions etc. -->

