### PR TITLE
Add multi-platform CI testing (Linux, macOS, Windows)

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -6,8 +6,11 @@ on:
 
 jobs:
   check:
-    name: Check
-    runs-on: ubuntu-latest
+    name: Check (${{ matrix.os }})
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -37,8 +40,11 @@ jobs:
         run: cargo check --all-targets
 
   test:
-    name: Test Suite
-    runs-on: ubuntu-latest
+    name: Test Suite (${{ matrix.os }})
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
Expands CI to test on all major platforms to catch platform-specific issues.

## Changes
- Updated `.github/workflows/pr.yml` with matrix strategy
- Check and test jobs now run on: Linux, macOS, Windows
- Lints remain Linux-only (results are platform-independent)

## Benefits
- Catches path separator differences (/ vs \\)
- Detects line ending issues (LF vs CRLF)
- Identifies file permission differences
- Validates CLI works on all target platforms

## Platform-Specific Considerations
- **Windows**: Path separators, file permissions, terminal colors
- **macOS**: Intel vs Apple Silicon (both covered by macos-latest)
- **Linux**: Baseline platform, most common in CI

## Testing
- [ ] Workflow runs successfully on all three platforms
- [ ] All tests pass on each platform
- [ ] Build times are acceptable

## Related
- Closes #31
- Part of CI/CD improvements
- No version bump (infrastructure only)

Ready for review - validating multi-platform support before adding code coverage.