### PR TITLE
Add test count and coverage badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # FindeRS
 
 [![CI](https://github.com/ydkadri/finders/actions/workflows/pr.yml/badge.svg)](https://github.com/ydkadri/finders/actions/workflows/pr.yml)
+![Tests](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/ydkadri/5616380737bada94e84764d02b816b38/raw/finders-tests.json)
+![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/ydkadri/5616380737bada94e84764d02b816b38/raw/finders-coverage.json)
 [![Benchmarks](https://github.com/ydkadri/finders/actions/workflows/benchmark.yml/badge.svg)](https://github.com/ydkadri/finders/actions/workflows/benchmark.yml)
 [![Crates.io](https://img.shields.io/crates/v/finders.svg)](https://crates.io/crates/finders)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)


### PR DESCRIPTION
Add the gist-based test count and coverage badges that were set up in PR #40.

**Badges added:**
- Test count badge (shows number of passing tests)
- Coverage badge (shows code coverage percentage)

Both badges are automatically updated by the `update-coverage-badge.yml` workflow on pushes to main.