### PR TITLE
Round coverage percentage to nearest integer in badge

### DIFF
--- a/.github/workflows/update-coverage-badge.yml
+++ b/.github/workflows/update-coverage-badge.yml
@@ -43,8 +43,9 @@ jobs:
           echo "test_count=$TEST_COUNT" >> $GITHUB_OUTPUT
           echo "Tests: $TEST_COUNT passing"
 
-          # Extract coverage percentage from JSON
-          COVERAGE=$(jq -r '.data[0].totals.lines.percent' coverage.json)
+          # Extract coverage percentage from JSON and round to nearest integer
+          COVERAGE_RAW=$(jq -r '.data[0].totals.lines.percent' coverage.json)
+          COVERAGE=$(printf "%.0f" "$COVERAGE_RAW")
           echo "coverage=$COVERAGE" >> $GITHUB_OUTPUT
           echo "Coverage: $COVERAGE%"
 


### PR DESCRIPTION
Rounds the coverage percentage displayed in the badge to the nearest integer for cleaner appearance.

**Before:** `75.123456789%`  
**After:** `75%`

**Changes:**
- Extract raw coverage value from JSON
- Use `printf "%.0f"` to round to nearest integer
- Display rounded value in badge

Badge will update on next push to main.