### PR TITLE
Fix gh-pages branch initialization (second attempt)

### DIFF
--- a/.github/workflows/comparison.yml
+++ b/.github/workflows/comparison.yml
@@ -65,29 +65,25 @@ jobs:
           # Note: Detailed results are in target/criterion/
           echo "Benchmark completed for version $VERSION"
 
-      - name: Checkout gh-pages branch
-        id: checkout-gh-pages
-        continue-on-error: true
-        uses: actions/checkout@v4
-        with:
-          ref: gh-pages
-          path: gh-pages-deploy
-
-      - name: Initialize gh-pages if needed
+      - name: Setup gh-pages deployment directory
         run: |
-          if [ ! -d "gh-pages-deploy" ] || [ ! -d "gh-pages-deploy/.git" ]; then
-            echo "Creating new gh-pages branch..."
-            rm -rf gh-pages-deploy
-            mkdir -p gh-pages-deploy
-            cd gh-pages-deploy
-            git init
-            git config user.name "github-actions[bot]"
-            git config user.email "github-actions[bot]@users.noreply.github.com"
-            git checkout -b gh-pages
-            echo "# FindeRS Benchmarks" > README.md
-            git add README.md
-            git commit -m "Initialize gh-pages branch"
-          fi
+          # Remove any existing directory and start fresh
+          rm -rf gh-pages-deploy
+          mkdir -p gh-pages-deploy
+          cd gh-pages-deploy
+
+          # Initialize git repo
+          git init
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -b gh-pages
+
+          # Try to fetch existing gh-pages content if it exists
+          git remote add origin "https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git"
+          git fetch origin gh-pages:gh-pages 2>/dev/null || echo "No existing gh-pages branch, will create new one"
+
+          # If branch exists, check it out; otherwise we already have an empty gh-pages
+          git checkout gh-pages 2>/dev/null || echo "Starting with new gh-pages branch"
 
       - name: Update benchmark history
         run: |


### PR DESCRIPTION
## Summary
Further fixes to the gh-pages deployment workflow to handle branch initialization correctly.

## Root Cause

The previous fix added `continue-on-error` to the checkout step, but this left a partial/broken `gh-pages-deploy` directory even when checkout failed. The initialization logic couldn't detect this bad state.

## Solution

Simplify the approach - always start fresh:

1. **Remove** any existing `gh-pages-deploy` directory (`rm -rf`)
2. **Initialize** new git repo
3. **Fetch** existing gh-pages branch if it exists (preserves history.json)
4. **Checkout** the branch (or start with empty if doesn't exist)
5. **Force-push** at the end ensures deployment regardless of state

## Handles Both Cases

✅ **First run** (no gh-pages branch yet): Creates new orphan branch  
✅ **Subsequent runs**: Fetches existing content to preserve history

## Testing

After merge, the workflow should:
- ✅ Successfully initialize gh-pages on first run
- ✅ Fetch and update existing branch on subsequent runs
- ✅ Deploy to https://ydkadri.github.io/finders/

## Related

- Fixes workflow run: https://github.com/ydkadri/finders/actions/runs/23971036651
- Previous attempt: PR #46 (merged but incomplete)
- Original feature: #37, PR #45