### PR TITLE
Add write permissions to comparison workflow

### DIFF
--- a/.github/workflows/comparison.yml
+++ b/.github/workflows/comparison.yml
@@ -10,6 +10,8 @@ jobs:
   benchmark:
     name: Run Comparison Benchmarks
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
       - name: Checkout sources


### PR DESCRIPTION
## Summary
Fixes 403 permission error when workflow tries to push to gh-pages branch.

## Error

```
fatal: unable to access 'https://github.com/ydkadri/finders.git/': 
The requested URL returned error: 403
```

## Root Cause

The `GITHUB_TOKEN` in workflows defaults to **read-only permissions** for security. The workflow needs explicit write permission to push the gh-pages branch.

## Solution

Add `permissions` block to the job:

```yaml
permissions:
  contents: write
```

This grants the workflow permission to:
- ✅ Push to gh-pages branch
- ✅ Create the branch if it doesn't exist
- ✅ Force-push updates

## Testing

After merge, manually trigger the workflow:
- Should successfully push to gh-pages
- Should deploy to https://ydkadri.github.io/finders/

## Related

- Fixes workflow run: https://github.com/ydkadri/finders/actions/runs/23971256384
- Related to PR #45 (original feature), #46, #47 (previous fixes)