### PR TITLE
Add automatic tagging workflow on version bumps

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -1,0 +1,84 @@
+name: Auto Tag on Version Bump
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'Cargo.toml'
+
+permissions:
+  contents: write
+
+jobs:
+  auto-tag:
+    name: Create Tag on Version Bump
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 2  # Need previous commit to detect changes
+
+      - name: Check if version changed
+        id: version-check
+        run: |
+          # Get current version from Cargo.toml
+          CURRENT_VERSION=$(grep '^version = ' Cargo.toml | head -1 | sed 's/version = "\(.*\)"/\1/')
+          echo "current_version=$CURRENT_VERSION" >> $GITHUB_OUTPUT
+
+          # Get previous version from Cargo.toml
+          git checkout HEAD~1 -- Cargo.toml 2>/dev/null || true
+          PREVIOUS_VERSION=$(grep '^version = ' Cargo.toml | head -1 | sed 's/version = "\(.*\)"/\1/' || echo "")
+
+          # Restore current Cargo.toml
+          git checkout HEAD -- Cargo.toml
+
+          echo "previous_version=$PREVIOUS_VERSION" >> $GITHUB_OUTPUT
+
+          # Check if version changed
+          if [ "$CURRENT_VERSION" != "$PREVIOUS_VERSION" ] && [ -n "$PREVIOUS_VERSION" ]; then
+            echo "Version changed from $PREVIOUS_VERSION to $CURRENT_VERSION"
+            echo "changed=true" >> $GITHUB_OUTPUT
+          else
+            echo "Version unchanged or first commit"
+            echo "changed=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Check if tag already exists
+        id: tag-check
+        if: steps.version-check.outputs.changed == 'true'
+        run: |
+          TAG_NAME="v${{ steps.version-check.outputs.current_version }}"
+          if git ls-remote --tags origin | grep -q "refs/tags/$TAG_NAME$"; then
+            echo "Tag $TAG_NAME already exists"
+            echo "exists=true" >> $GITHUB_OUTPUT
+          else
+            echo "Tag $TAG_NAME does not exist"
+            echo "exists=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Create and push tag
+        if: steps.version-check.outputs.changed == 'true' && steps.tag-check.outputs.exists == 'false'
+        run: |
+          TAG_NAME="v${{ steps.version-check.outputs.current_version }}"
+          echo "Creating tag $TAG_NAME"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          git tag -a "$TAG_NAME" -m "Release $TAG_NAME"
+          git push origin "$TAG_NAME"
+
+          echo "✅ Created and pushed tag $TAG_NAME"
+
+      - name: Log result
+        if: always()
+        run: |
+          echo "Version check result:"
+          echo "  Current version: ${{ steps.version-check.outputs.current_version }}"
+          echo "  Previous version: ${{ steps.version-check.outputs.previous_version }}"
+          echo "  Changed: ${{ steps.version-check.outputs.changed }}"
+          if [ "${{ steps.version-check.outputs.changed }}" == "true" ]; then
+            echo "  Tag exists: ${{ steps.tag-check.outputs.exists }}"
+          fi


### PR DESCRIPTION
## Summary
Automates tag creation when `Cargo.toml` version is bumped, eliminating manual `git tag` commands.

## How It Works
When a PR with a version bump is merged to main:
1. Workflow detects version change in `Cargo.toml`
2. Extracts new version (e.g., "2.1.2")
3. Creates and pushes tag `v2.1.2`
4. Existing `release.yml` workflow triggers → publishes to crates.io

## Benefits
- ✅ Fully automated release process
- ✅ Version bump = explicit release intent
- ✅ No manual steps to forget
- ✅ Simple ~70 line workflow

## Workflow Features
- Version change detection
- Duplicate tag prevention
- Clear action logging
- Only triggers on `Cargo.toml` changes to main

## Testing Plan
- Merge this PR (no version bump, should be no-op)
- Next PR with version bump will test auto-tagging

## Related
- Implements "Option 3" from release process discussion
- Complements existing `release.yml` workflow