### PR TITLE
Fix release workflow tag_name for manual triggers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,6 +54,7 @@ jobs:
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
+          tag_name: ${{ github.event.inputs.tag || github.ref_name }}
           files: |
             target/release/finder
           draft: false


### PR DESCRIPTION
## Summary
- Add explicit `tag_name` parameter to `action-gh-release` step
- Fixes failure when workflow is manually triggered via `workflow_dispatch`

## Problem
When manually triggering the release workflow, it failed with:
```
⚠️ GitHub Releases requires a tag
```

The `action-gh-release` action couldn't determine which tag to use because it relies on `github.ref` by default, which is empty for manual triggers.

## Solution
Explicitly set `tag_name` parameter:
```yaml
tag_name: ${{ github.event.inputs.tag || github.ref_name }}
```

This uses:
- `github.event.inputs.tag` when manually triggered
- `github.ref_name` when triggered by tag push event

## Test Plan
- [ ] Merge this PR
- [ ] Manually trigger release workflow for v2.1.2
- [ ] Verify release is created successfully with binaries
- [ ] Test automatic triggering with next version bump

🤖 Generated with [Claude Code](https://claude.com/claude-code)