### PR TITLE
Add cross-platform builds and checksums to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,9 +15,28 @@ permissions:
   contents: write
 
 jobs:
-  create-release:
-    name: Create Release
-    runs-on: ubuntu-latest
+  build-binaries:
+    name: Build ${{ matrix.target }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            archive: tar.gz
+            binary: finder
+          - os: macos-13
+            target: x86_64-apple-darwin
+            archive: tar.gz
+            binary: finder
+          - os: macos-14
+            target: aarch64-apple-darwin
+            archive: tar.gz
+            binary: finder
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
+            archive: zip
+            binary: finder.exe
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -51,12 +70,56 @@ jobs:
       - name: Build release binary
         run: cargo build --release
 
+      - name: Upload binary artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.target }}-binary
+          path: target/release/${{ matrix.binary }}
+          if-no-files-found: error
+
+  publish-release:
+    name: Publish Release
+    runs-on: ubuntu-latest
+    needs: build-binaries
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.tag || github.ref }}
+
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: Create archives and checksums
+        run: |
+          mkdir -p release
+          VERSION="${{ github.event.inputs.tag || github.ref_name }}"
+
+          # Linux x86_64
+          tar -czf release/finder-${VERSION}-x86_64-linux.tar.gz -C artifacts/x86_64-unknown-linux-gnu-binary finder
+          sha256sum release/finder-${VERSION}-x86_64-linux.tar.gz > release/finder-${VERSION}-x86_64-linux.tar.gz.sha256
+
+          # macOS x86_64
+          tar -czf release/finder-${VERSION}-x86_64-macos.tar.gz -C artifacts/x86_64-apple-darwin-binary finder
+          sha256sum release/finder-${VERSION}-x86_64-macos.tar.gz > release/finder-${VERSION}-x86_64-macos.tar.gz.sha256
+
+          # macOS aarch64
+          tar -czf release/finder-${VERSION}-aarch64-macos.tar.gz -C artifacts/aarch64-apple-darwin-binary finder
+          sha256sum release/finder-${VERSION}-aarch64-macos.tar.gz > release/finder-${VERSION}-aarch64-macos.tar.gz.sha256
+
+          # Windows x86_64
+          cd artifacts/x86_64-pc-windows-msvc-binary
+          zip ../../release/finder-${VERSION}-x86_64-windows.zip finder.exe
+          cd ../..
+          sha256sum release/finder-${VERSION}-x86_64-windows.zip > release/finder-${VERSION}-x86_64-windows.zip.sha256
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ github.event.inputs.tag || github.ref_name }}
-          files: |
-            target/release/finder
+          files: release/*
           draft: false
           prerelease: false
           generate_release_notes: true
@@ -66,7 +129,7 @@ jobs:
   publish-crate:
     name: Publish to crates.io
     runs-on: ubuntu-latest
-    needs: create-release
+    needs: publish-release
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- Build binaries for 4 platforms: Linux x64, macOS Intel/ARM, Windows x64
- Create compressed archives (tar.gz/zip) with SHA256 checksums
- Attach all archives and checksums to GitHub releases

Addresses #34 and #35.

## Changes

### Build Matrix
Replaced single `create-release` job with `build-binaries` matrix job:
- **Linux x86_64**: `ubuntu-latest` → `finder-v{version}-x86_64-linux.tar.gz`
- **macOS Intel**: `macos-13` → `finder-v{version}-x86_64-macos.tar.gz`
- **macOS ARM**: `macos-14` → `finder-v{version}-aarch64-macos.tar.gz`
- **Windows x64**: `windows-latest` → `finder-v{version}-x86_64-windows.zip`

Each platform:
1. Runs tests natively
2. Builds release binary
3. Uploads artifact

### Publish Release Job
New `publish-release` job downloads all binaries and:
1. Creates archives with standardized naming
2. Generates SHA256 checksums for each archive
3. Creates GitHub release with all files

### Dependencies
- `publish-release` needs `build-binaries`
- `publish-crate` needs `publish-release` (unchanged functionality)

## Benefits
- ✅ Users can download binaries without installing Rust/cargo
- ✅ Native builds for each platform (no cross-compilation complexity)
- ✅ Tests run on actual target platforms
- ✅ Checksums verify download integrity
- ✅ Standardized archive naming

## Testing
Can test after merge by:
1. Manually triggering workflow with existing v2.1.2 tag
2. Or naturally with next release (v2.2.0)

## Version Bump
None - workflow-only changes, no code modifications.

🤖 Generated with [Claude Code](https://claude.com/claude-code)