### PR TITLE
Add colored output and multiple output modes (v3.0.0 - BREAKING)

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -71,7 +71,7 @@ jobs:
           key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Run cargo test
-        run: cargo test --all-features
+        run: cargo test --all-features -- --test-threads=1
 
   lints:
     name: Lints

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,202 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [3.0.0] - 2026-04-05
+
+### ⚠️ BREAKING CHANGES
+
+#### Output Format Standardization
+
+The output format has changed to match industry standard (grep/ripgrep).
+
+**Before (v2.x):**
+```
+   4: /path/to/file.rs                                      line content
+```
+
+**After (v3.0.0):**
+```
+/path/to/file.rs:4: line content
+```
+
+**What changed:**
+- Line number position: moved from beginning to after path
+- Format: now `path:line: content` (consistent structure)
+- Fixed-width padding: removed (was 56 characters)
+- File-only mode: paths no longer have quotes
+
+**Impact:**
+- Scripts parsing finder output WILL BREAK
+- You must update any scripts that parse finder output
+- Pattern to match: `path:line: content`
+
+**Migration:**
+```bash
+# OLD parsing (v2.x):
+finder . -s "pattern" | awk '{print $2}'  # Extract path
+
+# NEW parsing (v3.0.0):
+finder . -s "pattern" | cut -d: -f1       # Extract path
+finder . -s "pattern" | cut -d: -f2       # Extract line number
+```
+
+**For stable output:** Use `--json` flag:
+```bash
+finder . -s "pattern" --json | jq '.[] | .path'
+```
+
+**Why this change:**
+- Matches grep/ripgrep standard format (familiar to users)
+- Easier to parse programmatically (consistent structure)
+- Better handling of long paths and narrow terminals
+- Simpler, more maintainable codebase
+
+### Added
+
+#### Coloured Output
+
+- **CLI Flags:**
+  - `--colour`: Force coloured output on
+  - `--no-colour`: Force coloured output off
+  - Default: Auto-detect TTY (colours in terminal, none when piped)
+
+- **Colour Scheme:**
+  - File paths: Green
+  - Line numbers: Cyan
+  - Match highlighting: Bold white text on blue background
+
+- **Environment Variables:**
+  - `NO_COLOR`: Universal opt-out from colour (https://no-color.org/)
+  - `CLICOLOR`: Enable/disable with TTY respect (https://bixense.com/clicolors/)
+  - `CLICOLOR_FORCE`: Force colours on, ignore TTY detection
+
+- **Priority:** `--colour`/`--no-colour` > `NO_COLOR` > `CLICOLOR_FORCE` > `CLICOLOR` > auto-detect
+
+```bash
+# Force colours when piping to less
+finder . -s "pattern" --colour | less -R
+
+# Disable colours for scripting
+NO_COLOR=1 finder . -s "pattern"
+```
+
+#### Multiple Output Modes
+
+**Files-with-matches mode (`-l`):**
+Output only file paths containing matches (like `grep -l`)
+```bash
+finder . -s "TODO" -l
+# Output:
+# src/lib.rs
+# src/main.rs
+```
+
+**Count mode (`-c`):**
+Output match count per file (like `grep -c`)
+```bash
+finder . -s "FIXME" -c
+# Output:
+# src/lib.rs:3
+# src/main.rs:7
+```
+
+**JSON mode (`--json`):**
+Output structured JSON for machine processing
+```bash
+finder . -s "error" --json | jq '.[] | select(.matches | length > 5)'
+```
+
+JSON format:
+```json
+[
+  {
+    "path": "src/lib.rs",
+    "matches": [
+      {"line": 42, "content": "matching line"},
+      {"line": 67, "content": "another match"}
+    ]
+  }
+]
+```
+
+**Mutual exclusivity:** Only one output mode can be specified at a time. Clap enforces this and shows clear error messages.
+
+### Changed
+
+- Output abstraction: Refactored output handling to use trait-based design for extensibility
+- Function signatures: `search_files` now accepts `&mut dyn Outputs` instead of specific types
+
+### Dependencies
+
+- Added `termcolor` 1.4 for cross-platform coloured output
+- Added `serde` 1.0 with derive feature for JSON serialisation
+- Added `serde_json` 1.0 for JSON output
+
+### Documentation
+
+- Added ADR 0002: Output abstraction and v3.0.0 breaking changes
+- Created interface design document: `docs/interface-v3.0.0.md`
+- Updated README with new features and examples
+
+## [2.1.2] - 2026-04-04
+
+### Fixed
+
+- Fixed regex error handling to return proper errors instead of panicking
+- Removed `unwrap()` calls in file finder and library code
+- Added graceful handling of non-UTF8 file paths and binary files
+
+### Added
+
+- Integration tests for error handling scenarios
+- Tests for binary file handling
+- Tests for regex error cases
+
+### Changed
+
+- Improved error messages for invalid regex patterns
+- Better handling of filesystem permission errors
+
+## [2.1.1] - 2026-04-03
+
+### Added
+
+- Comparison benchmarks vs find+grep and ripgrep
+- Benchmark workflow automation
+- Performance regression detection
+
+### Fixed
+
+- Binary detection in benchmarks
+- Result parsing for accurate comparisons
+
+## [2.1.0] - 2026-04-02
+
+### Added
+
+- Cross-platform CI testing (Linux, macOS, Windows)
+- Code coverage tracking with badges
+- Security vulnerability scanning (cargo-audit)
+- Project documentation structure
+- ADR (Architecture Decision Records) framework
+
+### Changed
+
+- Improved CI workflow organization
+- Enhanced test coverage reporting
+
+## [2.0.0] - Earlier
+
+Initial public release with basic functionality.
+
+[Unreleased]: https://github.com/ydkadri/finders/compare/v3.0.0...HEAD
+[3.0.0]: https://github.com/ydkadri/finders/compare/v2.1.2...v3.0.0
+[2.1.2]: https://github.com/ydkadri/finders/compare/v2.1.1...v2.1.2
+[2.1.1]: https://github.com/ydkadri/finders/compare/v2.1.0...v2.1.1
+[2.1.0]: https://github.com/ydkadri/finders/compare/v2.0.0...v2.1.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,6 +41,7 @@ These principles guide how we work together:
 - **Code Quality**: rustfmt, clippy
 - **CI/CD**: GitHub Actions (personal project)
 - **Distribution**: crates.io, GitHub releases with binaries
+- **Spelling**: British English (colour, behaviour, optimise, etc.) for all documentation, comments, and user-facing text. Preserve US spelling only in external crate names, environment variable standards, and code identifiers where required by convention.
 
 ---
 
@@ -487,5 +488,5 @@ Before pushing code or marking PR ready:
 
 ---
 
-**Last Updated**: 2026-04-04  
-**Current Version**: 2.1.2
+**Last Updated**: 2026-04-05  
+**Current Version**: 3.0.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -239,11 +239,14 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "finders"
-version = "2.1.2"
+version = "3.0.0"
 dependencies = [
  "clap",
  "criterion",
  "regex",
+ "serde",
+ "serde_json",
+ "termcolor",
  "walkdir",
 ]
 
@@ -519,6 +522,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "finders"
-version = "2.1.2"
+version = "3.0.0"
 edition = "2024"
 authors = ["Youcef Kadri <youcef.d.kadri@gmail.com>"]
 readme = "README.md"
@@ -16,6 +16,9 @@ exclude = [
 [dependencies]
 clap = { version = "4.5.3", features = ["derive"] }
 regex = "1.8.3"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+termcolor = "1.4"
 walkdir = "2.5.0"
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -40,8 +40,74 @@ Options:
   -r, --regex-pattern <REGEX_PATTERN>    Regex pattern to match in result files
   -i, --case-insensitive                 Flag for case insensitive search
   -v, --verbose                          Verbose output details unreadable files
+  -l, --files-with-matches               Output only file paths with matches (like grep -l)
+  -c, --count                            Output match count per file (like grep -c)
+      --json                             Output results as JSON
+      --colour                           Enable coloured output (force on)
+      --no-colour                        Disable coloured output (force off)
   -h, --help                             Print help
   -V, --version                          Print version
+```
+
+### Features
+
+#### Coloured Output
+FindeRS supports coloured output for better readability:
+- **File paths**: Green
+- **Line numbers**: Cyan  
+- **Matches**: Bold white on blue background
+
+Colours auto-detect when outputting to a terminal and disable when piped. Control with:
+```shell
+# Force colours on (useful for piping to less)
+finder . -s "pattern" --colour | less -R
+
+# Force colours off
+finder . -s "pattern" --no-colour
+
+# Respect NO_COLOR environment variable
+NO_COLOR=1 finder . -s "pattern"
+```
+
+Respects [NO_COLOR](https://no-color.org/) and [CLICOLORS](https://bixense.com/clicolors/) standards.
+
+#### Multiple Output Modes
+
+**Standard output (default):**
+```shell
+finder . -s "TODO"
+# Output: path:line: content
+# src/lib.rs:42: // TODO: implement this
+```
+
+**Files-only mode (`-l`):**
+```shell
+finder . -s "TODO" -l
+# Output: file paths only
+# src/lib.rs
+# src/main.rs
+```
+
+**Count mode (`-c`):**
+```shell
+finder . -s "FIXME" -c
+# Output: path:count
+# src/lib.rs:3
+# src/main.rs:7
+```
+
+**JSON mode (`--json`):**
+```shell
+finder . -s "error" --json | jq
+# Output: structured JSON
+[
+  {
+    "path": "src/lib.rs",
+    "matches": [
+      {"line": 42, "content": "error handling"}
+    ]
+  }
+]
 ```
 
 ### Performance

--- a/docs/adr/0002-output-abstraction-and-v3-breaking-changes.md
+++ b/docs/adr/0002-output-abstraction-and-v3-breaking-changes.md
@@ -1,0 +1,203 @@
+# ADR 0002: Output Abstraction and v3.0.0 Breaking Changes
+
+## Status
+
+Accepted
+
+## Context
+
+FindeRS v2.x had hardcoded output formatting with `println!` calls scattered throughout the codebase. As the tool matured, users requested:
+1. Colored output for better readability
+2. Multiple output modes (files-only, count, JSON) for different use cases
+3. Machine-readable output for scripting
+
+Additionally, the custom output format (`   4: /path/to/file.rs          content`) differed from industry standards like grep/ripgrep, making it harder for users familiar with those tools.
+
+## Decision
+
+We decided to:
+
+1. **Create an Output trait abstraction** to decouple output formatting from search logic
+2. **Standardize output format** to `path:line: content` (matching grep/ripgrep)
+3. **Add coloured output** with community-standard environment variable support
+4. **Implement multiple output modes** via trait implementations
+5. **Version as 3.0.0 (MAJOR)** due to breaking output format change
+
+### Output Trait Design
+
+```rust
+pub trait Output {
+    fn write_match(&mut self, match_result: &SearchMatch);
+    fn write_file(&mut self, path: &Path);
+    fn finalize(&mut self) {}
+}
+```
+
+**Rationale:**
+- Simple, focused interface
+- `write_match`: handles search results
+- `write_file`: handles file-only mode
+- `finalize`: allows buffered outputs (JSON, count) to flush
+
+### Output Implementations
+
+1. **StandardOutput**: Default `path:line: content` format with colours
+2. **FilesOnlyOutput**: Only paths (like `grep -l`)
+3. **CountOutput**: Match counts per file (like `grep -c`)
+4. **JsonOutput**: Structured JSON for machine processing
+
+**Rationale:**
+- Trait objects (`Box<dyn Output>`) enable runtime mode selection
+- Each implementation is self-contained and testable
+- Easy to add new output modes in future
+
+### Color Library Choice: termcolor
+
+**Alternatives considered:**
+- `colored` crate: Simple API but less flexible
+- `owo-colors` crate: Modern, but termcolor is industry standard
+- `ansi_term` crate: Deprecated
+
+**Chosen: termcolor**
+- Cross-platform (Windows, Unix)
+- Built-in TTY detection via `ColorChoice::Auto`
+- Used by ripgrep and other mature Rust CLI tools
+- Integrates with `StandardStream` for proper buffering
+
+### Environment Variable Standards
+
+Implemented full compliance with:
+- **NO_COLOR** (https://no-color.org/): Universal opt-out
+- **CLICOLOR** + **CLICOLOR_FORCE** (https://bixense.com/clicolors/): BSD/macOS standard
+
+**Priority order:**
+1. CLI flags (`--colour`/`--no-colour`)
+2. `NO_COLOR`
+3. `CLICOLOR_FORCE`
+4. `CLICOLOR`
+5. Auto-detect TTY
+
+**Rationale:** Respecting community standards improves compatibility with user workflows and other tools.
+
+### Color Scheme
+
+- **Paths**: Green (visible, not harsh)
+- **Line numbers**: Cyan (distinct from paths)
+- **Matches**: White on Magenta (high contrast, different from grep's red)
+
+**Rationale:**
+- Works on both dark and light terminals
+- Green/cyan combination is common in CLI tools
+- Magenta background chosen over red for distinctiveness
+
+### Output Format Breaking Change
+
+**Old (v2.x):**
+```
+   4: /path/to/file.rs                                      line content
+```
+
+**New (v3.0.0):**
+```
+/path/to/file.rs:4: line content
+```
+
+**Justification for MAJOR version bump:**
+- CLI output is the primary API for a CLI tool
+- Scripts parsing output WILL break
+- Better to be conservative and clearly signal change
+- Matches ecosystem norms (ripgrep treats output changes as major)
+
+**Benefits of new format:**
+- **Standard structure**: Matches grep/ripgrep (easier to learn)
+- **Easier parsing**: Consistent `path:line: content` pattern
+- **Better UX**: No fixed-width padding (handles long paths, narrow terminals)
+- **Future-proof**: Simpler to maintain and extend
+
+### JSON Output Design
+
+**Format:**
+```json
+[
+  {
+    "path": "src/lib.rs",
+    "matches": [
+      {"line": 42, "content": "..."}
+    ]
+  }
+]
+```
+
+**Rationale:**
+- Array of objects (one per file) is standard JSON structure
+- Sorted by path for deterministic output
+- Simple schema easy to parse with jq or other tools
+- Provides stable API for scripts (unlike text format which may change)
+
+### Mutual Exclusivity via Clap
+
+Output modes enforced declaratively via clap's `conflicts_with` attributes rather than runtime validation.
+
+**Rationale:**
+- Clearer error messages from clap
+- No code needed - declarative
+- Faster failure (at parse time, not runtime)
+
+## Consequences
+
+### Positive
+
+1. **Extensibility**: Adding new output modes requires only implementing the trait
+2. **Testability**: Each output mode can be tested independently
+3. **User choice**: Multiple output modes serve different use cases
+4. **Standards compliance**: Respecting NO_COLOR/CLICOLOR improves compatibility
+5. **Familiar format**: Standard `path:line: content` reduces learning curve
+6. **Machine-readable**: JSON output enables robust scripting
+
+### Negative
+
+1. **Breaking change**: Existing scripts parsing output will break
+2. **Migration burden**: Users must update their scripts for v3.0.0
+3. **Increased complexity**: Trait objects add slight runtime overhead
+4. **Dependency increase**: Added termcolor, serde, serde_json
+
+### Mitigation
+
+1. **Clear communication**: BREAKING CHANGES section in CHANGELOG with migration guide
+2. **JSON for stability**: Recommend `--json` for scripts needing stable API
+3. **Version signal**: MAJOR bump (3.0.0) clearly indicates breaking change
+4. **Documentation**: Examples showing new format and migration patterns
+
+## Alternatives Considered
+
+### Alternative 1: Keep old format, add new modes separately
+
+**Pros:** No breaking change, gradual migration
+**Cons:** Two output formats to maintain, confusion about which is "standard"
+**Rejected:** Technical debt would accumulate; better to standardize once
+
+### Alternative 2: Make format configurable
+
+**Pros:** Users can choose format
+**Cons:** More complexity, testing burden, no clear default
+**Rejected:** CLI tools should have one good way to do things; configuration adds complexity
+
+### Alternative 3: Use string formatting instead of trait
+
+**Pros:** Simpler, no trait objects
+**Cons:** Output logic still scattered, harder to test, less extensible
+**Rejected:** Trait abstraction provides better separation of concerns
+
+## Related
+
+- GitHub Issue #17: Colored output
+- GitHub Issue #22: Multiple output modes
+- Interface Design: `docs/interface-v3.0.0.md`
+- CHANGELOG: Breaking changes section
+
+## References
+
+- NO_COLOR standard: https://no-color.org/
+- CLICOLORS specification: https://bixense.com/clicolors/
+- Semantic Versioning: https://semver.org/
+- termcolor crate: https://docs.rs/termcolor/

--- a/docs/interface-v3.0.0.md
+++ b/docs/interface-v3.0.0.md
@@ -1,0 +1,346 @@
+# Interface Design: v3.0.0 UX Enhancements
+
+**Features:** #17 (Colored Output) + #22 (Multiple Output Modes)  
+**Version:** 3.0.0 (MAJOR - Breaking Changes)  
+**Status:** Design Document
+
+---
+
+## Overview
+
+Adds coloured output and multiple output modes to improve user experience and enable better tooling integration.
+
+---
+
+## CLI Interface
+
+### New Flags
+
+#### Color Control
+```bash
+--colour          Enable coloured output (force on)
+--no-colour       Disable coloured output (force off)
+```
+
+**Default behavior:** Auto-detect TTY
+- Colors enabled when outputting to terminal
+- Colors disabled when piped or redirected
+- Respects `NO_COLOR` environment variable (disables if set)
+- Respects `CLICOLOR` environment variable (enable/disable with TTY respect)
+- Respects `CLICOLOR_FORCE` environment variable (force enable, ignore TTY)
+
+**Priority:** `--colour`/`--no-colour` flag > `NO_COLOR` > `CLICOLOR_FORCE` > `CLICOLOR` > auto-detect
+
+**Notes:**
+- UK spelling throughout CLI
+- No short flag (avoid confusion with `-c` for count)
+
+#### Output Modes
+```bash
+-l, --files-with-matches    Output only file paths with matches
+-c, --count                 Output match count per file (format: path:count)
+--json                      Output structured JSON
+```
+
+**Mutual exclusivity:** Only one output mode can be specified at a time.
+
+**Error behavior:** Exit with error if multiple output mode flags given.
+
+---
+
+## Output Formats
+
+### Default Output (with search pattern)
+```
+src/searcher.rs:42: This is a line with matching text in it
+src/lib.rs:67: Another line with a match here
+```
+
+**Format:** `path:line: content`
+
+**With colours:**
+- **Path**: Green (`\033[32m`)
+- **Line number**: Cyan (`\033[36m`)
+- **Separator** (`:`): Default (no color)
+- **Matches**: White text on Magenta background (`\033[37m\033[45m`)
+- **Reset**: After each colored segment (`\033[0m`)
+
+**Example colored:**
+```
+[GREEN]src/searcher.rs[RESET]:[CYAN]42[RESET]: This is a line with [WHITE][BG_MAGENTA]matching text[RESET] in it
+```
+
+### Files-Only Output (no search pattern)
+```
+src/searcher.rs
+src/lib.rs
+tests/integration.rs
+```
+
+**Format:** `path` (one per line, no quotes)
+
+**When triggered:**
+- No search pattern given: `finder .`
+- Search pattern with `-l` flag: `finder . -s "text" -l`
+
+**Note:** Current behavior preserved - no breaking changes.
+
+### Files-With-Matches Output (`-l`)
+```
+src/searcher.rs
+src/lib.rs
+```
+
+**Format:** `path` (one per line)
+
+**Behavior:** Only files that contain matches (like grep -l)
+
+**With colours:** Paths in green (if colors enabled)
+
+### Count Output (`-c`)
+```
+src/searcher.rs:3
+src/lib.rs:7
+tests/integration.rs:1
+```
+
+**Format:** `path:count`
+
+**With colours:** 
+- Path in green
+- Separator in default
+- Count in default
+
+### JSON Output (`--json`)
+```json
+[
+  {
+    "path": "src/searcher.rs",
+    "matches": [
+      {"line": 42, "content": "This is a line with matching text"},
+      {"line": 67, "content": "Another matching line"}
+    ]
+  },
+  {
+    "path": "src/lib.rs",
+    "matches": [
+      {"line": 15, "content": "A match here"}
+    ]
+  }
+]
+```
+
+**Format:** Array of objects, one per file with matches
+
+**Fields:**
+- `path` (string): File path
+- `matches` (array): Array of match objects
+  - `line` (number): Line number (1-indexed)
+  - `content` (string): Full line content
+
+**Notes:**
+- No colors in JSON output (always machine-readable)
+- Valid JSON array output
+- Empty array `[]` if no matches found
+
+---
+
+## Backwards Compatibility
+
+### Preserved Behaviors
+1. **No search pattern** → List all files matching file pattern
+   ```bash
+   finder . --file-pattern ".rs"
+   # Still outputs file paths, no change
+   ```
+
+2. **Search pattern output** → Format changes from custom alignment to standard
+   ```bash
+   # OLD: "   4: /path/to/file.rs                                      line content"
+   # NEW: "/path/to/file.rs:4: line content"
+   ```
+   **Impact:** Breaking change to output format, but more standard (matches grep/ripgrep)
+
+3. **Piped output** → No colors by default (already behavior, now explicit)
+   ```bash
+   finder . -s "text" | less
+   # No colors unless --colour specified
+   ```
+
+### Breaking Changes
+
+⚠️ **This is a MAJOR release (v3.0.0) due to breaking changes in output format.**
+
+#### Output Format Change (BREAKING)
+
+**What changed:**
+```bash
+# v2.x.x output:
+   4: /path/to/file.rs                                      line content
+
+# v3.0.0 output:
+/path/to/file.rs:4: line content
+```
+
+**Impact:**
+- Scripts parsing finder output WILL BREAK
+- Line number moved from beginning to after filename
+- Fixed-width padding removed
+- Path format changed (no quotes in file-only mode)
+
+**Why this change:**
+- Matches grep/ripgrep standard format (industry convention)
+- Easier to parse programmatically (consistent `path:line:content` structure)
+- Better handling of long paths and narrow terminals
+- More predictable output for scripting
+
+**Migration:**
+- Update scripts to parse new `path:line: content` format
+- Use `--json` mode for stable, machine-readable output
+- Test scripts with v3.0.0 before deploying to production
+
+---
+
+## Environment Variables
+
+Finder respects community standards for terminal color control.
+
+### NO_COLOR
+- **Type:** Presence check (any value disables colors)
+- **Effect:** Disables coloured output when set
+- **Standard:** [no-color.org](https://no-color.org/) - Universal opt-out from color
+- **Example:** `NO_COLOR=1 finder . -s "text"`
+
+### CLICOLOR
+- **Type:** Value check (zero disables, non-zero enables)
+- **Effect:** 
+  - `CLICOLOR=0` - Disable colors (even to TTY)
+  - `CLICOLOR=1` (or non-zero) - Enable colors IF outputting to terminal (respects TTY detection)
+- **Standard:** [CLICOLORS](https://bixense.com/clicolors/) - BSD/macOS color control convention
+- **Example:** 
+  ```bash
+  CLICOLOR=1 finder . -s "text"           # Colors ON (if TTY)
+  CLICOLOR=1 finder . -s "text" | cat     # Colors OFF (not TTY)
+  CLICOLOR=0 finder . -s "text"           # Colors OFF (forced)
+  ```
+
+### CLICOLOR_FORCE
+- **Type:** Value check (non-zero enables colors)
+- **Effect:** Forces coloured output when set to non-zero, EVEN when not outputting to terminal
+- **Standard:** [CLICOLORS](https://bixense.com/clicolors/) - BSD/macOS color control convention
+- **Example:** `CLICOLOR_FORCE=1 finder . -s "text" | less -R`
+- **Use case:** Piping coloured output to pagers that support ANSI codes
+
+**References:**
+- **NO_COLOR specification:** https://no-color.org/
+- **CLICOLORS specification:** https://bixense.com/clicolors/
+
+**Priority (highest to lowest):**
+1. CLI flags (`--colour` or `--no-colour`) - Explicit user choice
+2. `NO_COLOR` - Universal opt-out (overrides everything else)
+3. `CLICOLOR_FORCE` - Force colors on, ignore TTY detection
+4. `CLICOLOR` - Enable/disable with TTY respect
+5. Auto-detect TTY - Default behavior if no flags/env vars set
+
+---
+
+## Error Handling
+
+### Multiple Output Modes
+```bash
+$ finder . -s "text" --json --count
+Error: Cannot specify multiple output modes (--json, --count)
+```
+
+**Exit code:** 1
+
+### Invalid Flag Combinations
+```bash
+$ finder . --files-with-matches
+Error: --files-with-matches requires a search pattern
+```
+
+**Exit code:** 1
+
+---
+
+## Usage Examples
+
+### Basic colored search
+```bash
+finder . -s "function"
+# Outputs with colors (auto-detected TTY)
+```
+
+### Disable colors for scripting
+```bash
+finder . -s "TODO" --no-colour > todos.txt
+# Plain text output
+```
+
+### Get files to process
+```bash
+for file in $(finder . -s "deprecated" -l); do
+  echo "Processing $file"
+done
+```
+
+### Count matches
+```bash
+finder . -s "FIXME" -c
+# Shows: path:count for each file
+```
+
+### JSON for tooling
+```bash
+finder . -s "error" --json | jq '.[] | select(.matches | length > 5)'
+# Filter files with >5 matches
+```
+
+### Colors in pager
+```bash
+# Method 1: Use --colour flag
+finder . -s "fn" --colour | less -R
+
+# Method 2: Use CLICOLOR_FORCE environment variable
+CLICOLOR_FORCE=1 finder . -s "fn" | less -R
+```
+
+### Disable colors globally
+```bash
+# Disable for all commands that respect NO_COLOR
+export NO_COLOR=1
+finder . -s "text"
+# No colors in output
+```
+
+### Enable colors with TTY respect
+```bash
+# Enable colors only when outputting to terminal
+export CLICOLOR=1
+finder . -s "text"           # Colors shown (TTY)
+finder . -s "text" | cat     # No colors (piped)
+```
+
+---
+
+## Implementation Dependencies
+
+**Crates:**
+- `termcolor` - ANSI color output with TTY detection
+- `atty` - TTY detection for auto-color mode
+- `serde` + `serde_json` - JSON serialization
+
+**CLI changes:**
+- Add flags to `clap` parser
+- Add mutual exclusivity validation
+- Environment variable checking
+
+**Output refactoring:**
+- Centralize output formatting
+- Separate logic for each output mode
+- Color application based on flags/env/TTY
+
+---
+
+**Last Updated:** 2026-04-05

--- a/src/bin/finder.rs
+++ b/src/bin/finder.rs
@@ -2,6 +2,9 @@ use clap::Parser;
 use std::io::Error;
 
 use finders::file_finder;
+use finders::output::{
+    ColourMode, CountOutput, FilesOnlyOutput, JsonOutput, Outputs, StandardOutput,
+};
 use finders::search_files;
 use finders::searcher;
 
@@ -39,6 +42,26 @@ struct Cli {
     /// Verbose output details unreadable files
     #[arg(short, long)]
     verbose: bool,
+
+    /// Enable coloured output (force on)
+    #[arg(long, conflicts_with = "no_colour")]
+    colour: bool,
+
+    /// Disable coloured output (force off)
+    #[arg(long, conflicts_with = "colour")]
+    no_colour: bool,
+
+    /// Output only file paths with matches (like grep -l)
+    #[arg(short = 'l', long, conflicts_with = "count")]
+    files_with_matches: bool,
+
+    /// Output match count per file (like grep -c)
+    #[arg(short = 'c', long, conflicts_with = "files_with_matches")]
+    count: bool,
+
+    /// Output results as JSON
+    #[arg(long, conflicts_with_all = ["files_with_matches", "count"])]
+    json: bool,
 }
 
 fn main() -> Result<(), Error> {
@@ -54,11 +77,25 @@ fn main() -> Result<(), Error> {
     // Determine if verbose or not
     let verbose = cli.verbose;
 
+    // Determine colour mode from flags and environment
+    let colour_mode = ColourMode::from_env(cli.colour, cli.no_colour);
+
+    // Create output handler based on output mode flags
+    let mut output: Box<dyn Outputs> = if cli.json {
+        Box::new(JsonOutput::new(colour_mode))
+    } else if cli.files_with_matches {
+        Box::new(FilesOnlyOutput::new(colour_mode))
+    } else if cli.count {
+        Box::new(CountOutput::new(colour_mode))
+    } else {
+        Box::new(StandardOutput::new(colour_mode))
+    };
+
     if let Some(query) = cli.search_pattern.as_deref() {
         let case_insensitive = cli.case_insensitive;
         let searcher = searcher::Searcher::new(query, case_insensitive);
 
-        search_files(searcher, paths, verbose)?;
+        search_files(searcher, paths, verbose, &mut *output)?;
     } else if let Some(pattern) = cli.regex_pattern.as_deref() {
         let re_searcher = match searcher::ReSearcher::new(pattern) {
             Ok(searcher) => searcher,
@@ -68,10 +105,11 @@ fn main() -> Result<(), Error> {
             }
         };
 
-        search_files(re_searcher, paths, verbose)?;
+        search_files(re_searcher, paths, verbose, &mut *output)?;
     } else {
+        // File-only mode (no search pattern)
         for path in paths {
-            println!("{:?}", path);
+            output.write_file(&path);
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ use std::io::{BufRead, BufReader, Error, ErrorKind};
 use std::path::PathBuf;
 
 pub mod file_finder;
+pub mod output;
 pub mod searcher;
 
 const CHUNK_SIZE: usize = 8192; // 8KB chunks for reading files
@@ -11,10 +12,11 @@ pub fn search_files(
     searcher: impl searcher::Searches,
     paths: Vec<PathBuf>,
     verbose: bool,
+    output: &mut dyn output::Outputs,
 ) -> Result<(), Error> {
     // Process files one at a time in a streaming fashion
     for path in paths {
-        if let Err(e) = search_file(&searcher, &path, verbose) {
+        if let Err(e) = search_file(&searcher, &path, verbose, output) {
             if e.kind() == ErrorKind::InvalidData {
                 if verbose {
                     println!("Cannot read file: {:?}", path);
@@ -26,6 +28,7 @@ pub fn search_files(
         }
     }
 
+    output.finalize();
     Ok(())
 }
 
@@ -33,6 +36,7 @@ fn search_file(
     searcher: &impl searcher::Searches,
     path: &PathBuf,
     verbose: bool,
+    output: &mut dyn output::Outputs,
 ) -> Result<(), Error> {
     // Open file and create buffered reader for efficient streaming
     let file = match File::open(path) {
@@ -54,12 +58,13 @@ fn search_file(
             Ok(content) => {
                 // Search this single line
                 if let Some(result) = searcher.search_line(&content, rownum) {
-                    println!(
-                        "{:>4}: {:<56} {}",
-                        result.rownum,
-                        path.as_path().to_string_lossy(),
-                        result.line
-                    );
+                    let search_match = output::SearchMatch {
+                        path: path.as_path(),
+                        line_number: result.rownum,
+                        content: &result.line,
+                        match_positions: &result.match_positions,
+                    };
+                    output.write_match(&search_match);
                 }
                 rownum += 1;
             }
@@ -102,9 +107,10 @@ mod tests {
         // Test searching with case-sensitive searcher
         let searcher = searcher::Searcher::new("line", false);
         let paths = vec![test_file.clone()];
+        let mut output = output::StandardOutput::new(output::ColourMode::Never);
 
         // This should find 2 matches (lines 1 and 3)
-        let result = search_files(searcher, paths, false);
+        let result = search_files(searcher, paths, false, &mut output);
 
         // Clean up
         fs::remove_file(&test_file)?;
@@ -142,8 +148,9 @@ mod tests {
 
         let searcher = searcher::Searcher::new("line 500", false);
         let paths = vec![test_file.clone()];
+        let mut output = output::StandardOutput::new(output::ColourMode::Never);
 
-        let result = search_files(searcher, paths, false);
+        let result = search_files(searcher, paths, false, &mut output);
 
         // Clean up
         fs::remove_file(&test_file)?;

--- a/src/output/colour.rs
+++ b/src/output/colour.rs
@@ -1,0 +1,191 @@
+use std::env;
+use termcolor::ColorChoice;
+
+/// Colour mode for output
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ColourMode {
+    /// Auto-detect based on TTY
+    Auto,
+    /// Always use colours
+    Always,
+    /// Never use colours
+    Never,
+}
+
+impl ColourMode {
+    /// Determine colour mode from CLI flags and environment variables
+    ///
+    /// Priority:
+    /// 1. CLI flags (--colour or --no-colour)
+    /// 2. NO_COLOR environment variable
+    /// 3. CLICOLOR_FORCE environment variable
+    /// 4. CLICOLOR environment variable
+    /// 5. Auto-detect TTY (default)
+    pub fn from_env(colour_flag: bool, no_colour_flag: bool) -> Self {
+        // CLI flags have highest priority
+        if colour_flag {
+            return ColourMode::Always;
+        }
+        if no_colour_flag {
+            return ColourMode::Never;
+        }
+
+        // Check NO_COLOR (universal opt-out)
+        if env::var("NO_COLOR").is_ok() {
+            return ColourMode::Never;
+        }
+
+        // Check CLICOLOR_FORCE (force colours on)
+        if let Ok(val) = env::var("CLICOLOR_FORCE")
+            && val != "0"
+        {
+            return ColourMode::Always;
+        }
+
+        // Check CLICOLOR (enable/disable with TTY respect)
+        if let Ok(val) = env::var("CLICOLOR") {
+            if val == "0" {
+                return ColourMode::Never;
+            }
+            // Non-zero CLICOLOR means "use colours if TTY", which is Auto
+            return ColourMode::Auto;
+        }
+
+        // Default: auto-detect TTY
+        ColourMode::Auto
+    }
+
+    /// Convert to termcolor's ColorChoice
+    pub(crate) fn to_color_choice(self) -> ColorChoice {
+        match self {
+            ColourMode::Auto => ColorChoice::Auto,
+            ColourMode::Always => ColorChoice::Always,
+            ColourMode::Never => ColorChoice::Never,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_colour_flag_takes_priority() {
+        // CLI flags should override environment variables
+        assert_eq!(ColourMode::from_env(true, false), ColourMode::Always);
+        assert_eq!(ColourMode::from_env(false, true), ColourMode::Never);
+    }
+
+    #[test]
+    fn test_no_color_env() {
+        // Clean environment first
+        unsafe {
+            env::remove_var("NO_COLOR");
+            env::remove_var("CLICOLOR_FORCE");
+            env::remove_var("CLICOLOR");
+        }
+
+        // Set NO_COLOR environment variable
+        unsafe {
+            env::set_var("NO_COLOR", "1");
+        }
+        assert_eq!(ColourMode::from_env(false, false), ColourMode::Never);
+        unsafe {
+            env::remove_var("NO_COLOR");
+        }
+    }
+
+    #[test]
+    fn test_clicolor_force_env() {
+        // Clean environment first
+        unsafe {
+            env::remove_var("NO_COLOR");
+            env::remove_var("CLICOLOR_FORCE");
+            env::remove_var("CLICOLOR");
+        }
+
+        // CLICOLOR_FORCE=1 should force colours on
+        unsafe {
+            env::set_var("CLICOLOR_FORCE", "1");
+        }
+        assert_eq!(ColourMode::from_env(false, false), ColourMode::Always);
+        unsafe {
+            env::remove_var("CLICOLOR_FORCE");
+        }
+
+        // CLICOLOR_FORCE=0 should not force colours
+        unsafe {
+            env::set_var("CLICOLOR_FORCE", "0");
+        }
+        assert_eq!(ColourMode::from_env(false, false), ColourMode::Auto);
+        unsafe {
+            env::remove_var("CLICOLOR_FORCE");
+        }
+    }
+
+    #[test]
+    fn test_clicolor_env() {
+        // Clean environment first
+        unsafe {
+            env::remove_var("NO_COLOR");
+            env::remove_var("CLICOLOR_FORCE");
+            env::remove_var("CLICOLOR");
+        }
+
+        // CLICOLOR=0 should disable colours
+        unsafe {
+            env::set_var("CLICOLOR", "0");
+        }
+        assert_eq!(ColourMode::from_env(false, false), ColourMode::Never);
+        unsafe {
+            env::remove_var("CLICOLOR");
+        }
+
+        // CLICOLOR=1 should use auto-detection
+        unsafe {
+            env::set_var("CLICOLOR", "1");
+        }
+        assert_eq!(ColourMode::from_env(false, false), ColourMode::Auto);
+        unsafe {
+            env::remove_var("CLICOLOR");
+        }
+    }
+
+    #[test]
+    fn test_env_priority() {
+        // CLI flags > NO_COLOR > CLICOLOR_FORCE > CLICOLOR
+        unsafe {
+            env::set_var("NO_COLOR", "1");
+            env::set_var("CLICOLOR_FORCE", "1");
+            env::set_var("CLICOLOR", "1");
+        }
+
+        // CLI flag should win
+        assert_eq!(ColourMode::from_env(true, false), ColourMode::Always);
+
+        // NO_COLOR should win over CLICOLOR_FORCE
+        assert_eq!(ColourMode::from_env(false, false), ColourMode::Never);
+
+        unsafe {
+            env::remove_var("NO_COLOR");
+        }
+        // CLICOLOR_FORCE should win over CLICOLOR
+        assert_eq!(ColourMode::from_env(false, false), ColourMode::Always);
+
+        unsafe {
+            env::remove_var("CLICOLOR_FORCE");
+            env::remove_var("CLICOLOR");
+        }
+    }
+
+    #[test]
+    fn test_default_auto() {
+        // With no flags or env vars, should default to Auto
+        unsafe {
+            env::remove_var("NO_COLOR");
+            env::remove_var("CLICOLOR_FORCE");
+            env::remove_var("CLICOLOR");
+        }
+        assert_eq!(ColourMode::from_env(false, false), ColourMode::Auto);
+    }
+}

--- a/src/output/count.rs
+++ b/src/output/count.rs
@@ -1,0 +1,156 @@
+use std::io::{self, Write};
+use std::path::Path;
+use termcolor::{Color, ColorSpec, StandardStream, WriteColor};
+
+use super::{ColourMode, Outputs, SearchMatch};
+
+/// Count output mode (like grep -c)
+/// Outputs match count per file in format: path:count
+pub struct CountOutput {
+    stdout: StandardStream,
+    path_colour: ColorSpec,
+    current_file: Option<String>,
+    current_count: usize,
+}
+
+impl CountOutput {
+    pub fn new(colour_mode: ColourMode) -> Self {
+        let stdout = StandardStream::stdout(colour_mode.to_color_choice());
+
+        let mut path_colour = ColorSpec::new();
+        path_colour.set_fg(Some(Color::Green));
+
+        CountOutput {
+            stdout,
+            path_colour,
+            current_file: None,
+            current_count: 0,
+        }
+    }
+
+    fn write_coloured_path(&mut self, path: &Path) -> io::Result<()> {
+        self.stdout.set_color(&self.path_colour)?;
+        write!(self.stdout, "{}", path.to_string_lossy())?;
+        self.stdout.reset()?;
+        Ok(())
+    }
+
+    fn flush_current_file(&mut self) {
+        if let Some(ref path) = self.current_file
+            && self.current_count > 0
+        {
+            // Output path:count
+            let path_buf = std::path::PathBuf::from(path);
+            let _ = self.write_coloured_path(&path_buf);
+            let _ = write!(self.stdout, ":{}", self.current_count);
+            let _ = writeln!(self.stdout);
+            let _ = self.stdout.flush();
+        }
+    }
+}
+
+impl Default for CountOutput {
+    fn default() -> Self {
+        Self::new(ColourMode::Auto)
+    }
+}
+
+impl Outputs for CountOutput {
+    fn write_match(&mut self, match_result: &SearchMatch) {
+        let path_str = match_result.path.to_string_lossy().to_string();
+
+        // If we're starting a new file, flush the previous file's count
+        if self.current_file.as_ref() != Some(&path_str) {
+            self.flush_current_file();
+            self.current_file = Some(path_str);
+            self.current_count = 1;
+        } else {
+            self.current_count += 1;
+        }
+    }
+
+    fn write_file(&mut self, path: &Path) {
+        // For file-only mode, just output path with count 0
+        let _ = self.write_coloured_path(path);
+        let _ = write!(self.stdout, ":0");
+        let _ = writeln!(self.stdout);
+        let _ = self.stdout.flush();
+    }
+
+    fn finalize(&mut self) {
+        // Output the last file's count
+        self.flush_current_file();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    #[test]
+    fn test_count_aggregation() {
+        let mut output = CountOutput::new(ColourMode::Never);
+        let path = PathBuf::from("test.txt");
+
+        // Add multiple matches from same file
+        output.write_match(&SearchMatch {
+            path: &path,
+            line_number: 1,
+            content: "first match",
+            match_positions: &[(0, 5)],
+        });
+
+        output.write_match(&SearchMatch {
+            path: &path,
+            line_number: 3,
+            content: "second match",
+            match_positions: &[(0, 6)],
+        });
+
+        output.write_match(&SearchMatch {
+            path: &path,
+            line_number: 7,
+            content: "third match",
+            match_positions: &[(0, 5)],
+        });
+
+        // Verify count is accumulated
+        assert_eq!(output.current_file, Some("test.txt".to_string()));
+        assert_eq!(output.current_count, 3);
+    }
+
+    #[test]
+    fn test_count_multiple_files() {
+        let mut output = CountOutput::new(ColourMode::Never);
+        let path1 = PathBuf::from("file1.txt");
+        let path2 = PathBuf::from("file2.txt");
+
+        // Add matches to first file
+        output.write_match(&SearchMatch {
+            path: &path1,
+            line_number: 1,
+            content: "match",
+            match_positions: &[(0, 5)],
+        });
+
+        output.write_match(&SearchMatch {
+            path: &path1,
+            line_number: 2,
+            content: "match",
+            match_positions: &[(0, 5)],
+        });
+
+        // Switch to second file
+        output.write_match(&SearchMatch {
+            path: &path2,
+            line_number: 1,
+            content: "match",
+            match_positions: &[(0, 5)],
+        });
+
+        // Second file should be current with count 1
+        assert_eq!(output.current_file, Some("file2.txt".to_string()));
+        assert_eq!(output.current_count, 1);
+    }
+}

--- a/src/output/files_only.rs
+++ b/src/output/files_only.rs
@@ -1,0 +1,123 @@
+use std::io::{self, Write};
+use std::path::Path;
+use termcolor::{Color, ColorSpec, StandardStream, WriteColor};
+
+use super::{ColourMode, Outputs, SearchMatch};
+
+/// Files-only output mode (like grep -l)
+/// Outputs only file paths that contain matches, one per line
+pub struct FilesOnlyOutput {
+    stdout: StandardStream,
+    path_colour: ColorSpec,
+    current_file: Option<String>,
+}
+
+impl FilesOnlyOutput {
+    pub fn new(colour_mode: ColourMode) -> Self {
+        let stdout = StandardStream::stdout(colour_mode.to_color_choice());
+
+        let mut path_colour = ColorSpec::new();
+        path_colour.set_fg(Some(Color::Green));
+
+        FilesOnlyOutput {
+            stdout,
+            path_colour,
+            current_file: None,
+        }
+    }
+
+    fn write_coloured_path(&mut self, path: &Path) -> io::Result<()> {
+        self.stdout.set_color(&self.path_colour)?;
+        write!(self.stdout, "{}", path.to_string_lossy())?;
+        self.stdout.reset()?;
+        Ok(())
+    }
+}
+
+impl Default for FilesOnlyOutput {
+    fn default() -> Self {
+        Self::new(ColourMode::Auto)
+    }
+}
+
+impl Outputs for FilesOnlyOutput {
+    fn write_match(&mut self, match_result: &SearchMatch) {
+        // Only output each file path once (first match)
+        let path_str = match_result.path.to_string_lossy().to_string();
+        if self.current_file.as_ref() != Some(&path_str) {
+            let _ = self.write_coloured_path(match_result.path);
+            let _ = writeln!(self.stdout);
+            let _ = self.stdout.flush();
+            self.current_file = Some(path_str);
+        }
+    }
+
+    fn write_file(&mut self, path: &Path) {
+        // Same as StandardOutput for file-only mode
+        let _ = self.write_coloured_path(path);
+        let _ = writeln!(self.stdout);
+        let _ = self.stdout.flush();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    #[test]
+    fn test_files_only_deduplication() {
+        let mut output = FilesOnlyOutput::new(ColourMode::Never);
+        let path = PathBuf::from("test.txt");
+
+        // Add multiple matches from same file
+        output.write_match(&SearchMatch {
+            path: &path,
+            line_number: 1,
+            content: "first match",
+            match_positions: &[(0, 5)],
+        });
+
+        output.write_match(&SearchMatch {
+            path: &path,
+            line_number: 3,
+            content: "second match",
+            match_positions: &[(0, 6)],
+        });
+
+        output.write_match(&SearchMatch {
+            path: &path,
+            line_number: 7,
+            content: "third match",
+            match_positions: &[(0, 5)],
+        });
+
+        // Verify file is tracked (only output once)
+        assert_eq!(output.current_file, Some("test.txt".to_string()));
+    }
+
+    #[test]
+    fn test_files_only_multiple_files() {
+        let mut output = FilesOnlyOutput::new(ColourMode::Never);
+        let path1 = PathBuf::from("file1.txt");
+        let path2 = PathBuf::from("file2.txt");
+
+        // Add matches to different files
+        output.write_match(&SearchMatch {
+            path: &path1,
+            line_number: 1,
+            content: "match",
+            match_positions: &[(0, 5)],
+        });
+
+        output.write_match(&SearchMatch {
+            path: &path2,
+            line_number: 1,
+            content: "match",
+            match_positions: &[(0, 5)],
+        });
+
+        // Should track the second file
+        assert_eq!(output.current_file, Some("file2.txt".to_string()));
+    }
+}

--- a/src/output/json.rs
+++ b/src/output/json.rs
@@ -1,0 +1,158 @@
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::path::Path;
+
+use super::{ColourMode, Outputs, SearchMatch};
+
+/// JSON match representation
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct JsonMatch {
+    pub line: usize,
+    pub content: String,
+}
+
+/// JSON file representation
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct JsonFile {
+    pub path: String,
+    pub matches: Vec<JsonMatch>,
+}
+
+/// JSON output mode
+/// Outputs structured JSON for machine processing
+pub struct JsonOutput {
+    files: HashMap<String, Vec<JsonMatch>>,
+}
+
+impl JsonOutput {
+    pub fn new(_colour_mode: ColourMode) -> Self {
+        // JSON output never uses colours
+        JsonOutput {
+            files: HashMap::new(),
+        }
+    }
+}
+
+impl Default for JsonOutput {
+    fn default() -> Self {
+        Self::new(ColourMode::Never)
+    }
+}
+
+impl Outputs for JsonOutput {
+    fn write_match(&mut self, match_result: &SearchMatch) {
+        let path_str = match_result.path.to_string_lossy().to_string();
+
+        let json_match = JsonMatch {
+            line: match_result.line_number,
+            content: match_result.content.to_string(),
+        };
+
+        self.files.entry(path_str).or_default().push(json_match);
+    }
+
+    fn write_file(&mut self, path: &Path) {
+        // For file-only mode, add path with no matches
+        let path_str = path.to_string_lossy().to_string();
+        self.files.entry(path_str).or_default();
+    }
+
+    fn finalize(&mut self) {
+        // Convert HashMap to Vec of JsonFile and serialise
+        let mut output: Vec<JsonFile> = self
+            .files
+            .iter()
+            .map(|(path, matches)| JsonFile {
+                path: path.clone(),
+                matches: matches.clone(),
+            })
+            .collect();
+
+        // Sort by path for consistent output
+        output.sort_by(|a, b| a.path.cmp(&b.path));
+
+        // Serialise and print
+        match serde_json::to_string_pretty(&output) {
+            Ok(json) => println!("{}", json),
+            Err(e) => eprintln!("Error serialising JSON: {}", e),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    #[test]
+    fn test_json_match_serialisation() {
+        let json_match = JsonMatch {
+            line: 42,
+            content: "test content".to_string(),
+        };
+
+        let json = serde_json::to_string(&json_match).unwrap();
+        assert!(json.contains("\"line\":42"));
+        assert!(json.contains("\"content\":\"test content\""));
+    }
+
+    #[test]
+    fn test_json_file_serialisation() {
+        let json_file = JsonFile {
+            path: "src/test.rs".to_string(),
+            matches: vec![
+                JsonMatch {
+                    line: 1,
+                    content: "first line".to_string(),
+                },
+                JsonMatch {
+                    line: 5,
+                    content: "fifth line".to_string(),
+                },
+            ],
+        };
+
+        let json = serde_json::to_string(&json_file).unwrap();
+        assert!(json.contains("\"path\":\"src/test.rs\""));
+        assert!(json.contains("\"line\":1"));
+        assert!(json.contains("\"line\":5"));
+    }
+
+    #[test]
+    fn test_json_output_accumulates_matches() {
+        let mut output = JsonOutput::new(ColourMode::Never);
+        let path = PathBuf::from("test.txt");
+
+        // Add multiple matches from same file
+        output.write_match(&SearchMatch {
+            path: &path,
+            line_number: 1,
+            content: "first match",
+            match_positions: &[(0, 5)],
+        });
+
+        output.write_match(&SearchMatch {
+            path: &path,
+            line_number: 3,
+            content: "second match",
+            match_positions: &[(0, 6)],
+        });
+
+        // Verify matches are stored
+        assert_eq!(output.files.len(), 1);
+        assert_eq!(output.files.get("test.txt").unwrap().len(), 2);
+    }
+
+    #[test]
+    fn test_json_output_write_file() {
+        let mut output = JsonOutput::new(ColourMode::Never);
+        let path = PathBuf::from("empty.txt");
+
+        // Add file with no matches
+        output.write_file(&path);
+
+        // Verify file is stored with empty matches
+        assert_eq!(output.files.len(), 1);
+        assert_eq!(output.files.get("empty.txt").unwrap().len(), 0);
+    }
+}

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -1,0 +1,33 @@
+use std::path::Path;
+
+mod colour;
+mod count;
+mod files_only;
+mod json;
+mod standard;
+
+pub use colour::ColourMode;
+pub use count::CountOutput;
+pub use files_only::FilesOnlyOutput;
+pub use json::{JsonFile, JsonMatch, JsonOutput};
+pub use standard::StandardOutput;
+
+/// Result of a search match containing line number and content
+pub struct SearchMatch<'a> {
+    pub path: &'a Path,
+    pub line_number: usize,
+    pub content: &'a str,
+    pub match_positions: &'a [(usize, usize)], // (start, end) byte positions
+}
+
+/// Trait for different output formats
+pub trait Outputs {
+    /// Output a single search match
+    fn write_match(&mut self, match_result: &SearchMatch);
+
+    /// Output a file path (for file-only mode)
+    fn write_file(&mut self, path: &Path);
+
+    /// Finalise output (e.g., close JSON array)
+    fn finalize(&mut self) {}
+}

--- a/src/output/standard.rs
+++ b/src/output/standard.rs
@@ -1,0 +1,116 @@
+use std::io::{self, Write};
+use std::path::Path;
+use termcolor::{Color, ColorSpec, StandardStream, WriteColor};
+
+use super::{ColourMode, Outputs, SearchMatch};
+
+/// Standard output format with coloured output
+pub struct StandardOutput {
+    stdout: StandardStream,
+    // Colour specs for different elements
+    path_colour: ColorSpec,
+    line_number_colour: ColorSpec,
+    match_colour: ColorSpec,
+}
+
+impl StandardOutput {
+    pub fn new(colour_mode: ColourMode) -> Self {
+        let stdout = StandardStream::stdout(colour_mode.to_color_choice());
+
+        let mut path_colour = ColorSpec::new();
+        path_colour.set_fg(Some(Color::Green));
+
+        let mut line_number_colour = ColorSpec::new();
+        line_number_colour.set_fg(Some(Color::Cyan));
+
+        let mut match_colour = ColorSpec::new();
+        match_colour.set_fg(Some(Color::White));
+        match_colour.set_bg(Some(Color::Blue));
+        match_colour.set_bold(true);
+
+        StandardOutput {
+            stdout,
+            path_colour,
+            line_number_colour,
+            match_colour,
+        }
+    }
+
+    /// Write coloured path
+    fn write_coloured_path(&mut self, path: &Path) -> io::Result<()> {
+        self.stdout.set_color(&self.path_colour)?;
+        write!(self.stdout, "{}", path.to_string_lossy())?;
+        self.stdout.reset()?;
+        Ok(())
+    }
+
+    /// Write coloured line number
+    fn write_coloured_line_number(&mut self, line_num: usize) -> io::Result<()> {
+        self.stdout.set_color(&self.line_number_colour)?;
+        write!(self.stdout, "{}", line_num)?;
+        self.stdout.reset()?;
+        Ok(())
+    }
+
+    /// Write content with highlighted matches
+    fn write_highlighted_content(
+        &mut self,
+        content: &str,
+        match_positions: &[(usize, usize)],
+    ) -> io::Result<()> {
+        if match_positions.is_empty() {
+            // No matches to highlight, just write content
+            write!(self.stdout, "{}", content)?;
+            return Ok(());
+        }
+
+        let mut last_end = 0;
+        for (start, end) in match_positions {
+            // Write text before match
+            write!(self.stdout, "{}", &content[last_end..*start])?;
+            // Write highlighted match
+            self.stdout.set_color(&self.match_colour)?;
+            write!(self.stdout, "{}", &content[*start..*end])?;
+            self.stdout.reset()?;
+            last_end = *end;
+        }
+        // Write remaining text after last match
+        write!(self.stdout, "{}", &content[last_end..])?;
+        Ok(())
+    }
+}
+
+impl Default for StandardOutput {
+    fn default() -> Self {
+        Self::new(ColourMode::Auto)
+    }
+}
+
+impl Outputs for StandardOutput {
+    fn write_match(&mut self, match_result: &SearchMatch) {
+        // v3.0.0 standard format: "path:line: content"
+        // Matches grep/ripgrep conventions
+        // With colours:
+        // - Path: green
+        // - Line number: cyan
+        // - Separators: default
+        // - Content: default with highlighted matches (bold white on blue)
+
+        // Note: Ignoring errors for now since println! doesn't expose errors either
+        let _ = self.write_coloured_path(match_result.path);
+        let _ = write!(self.stdout, ":");
+        let _ = self.write_coloured_line_number(match_result.line_number);
+        let _ = write!(self.stdout, ": ");
+        let _ = self.write_highlighted_content(match_result.content, match_result.match_positions);
+        let _ = writeln!(self.stdout);
+        let _ = self.stdout.flush();
+    }
+
+    fn write_file(&mut self, path: &Path) {
+        // v3.0.0 format: plain path without quotes
+        // With colours: path in green
+        let _ = self.write_coloured_path(path);
+        let _ = writeln!(self.stdout);
+        let _ = self.stdout.flush();
+    }
+}

--- a/src/searcher.rs
+++ b/src/searcher.rs
@@ -5,6 +5,7 @@ use regex::Regex;
 pub struct SearchResult {
     pub rownum: usize,
     pub line: String,
+    pub match_positions: Vec<(usize, usize)>, // (start, end) byte positions of matches
 }
 
 // Structs for basic and regex searchers
@@ -26,8 +27,12 @@ pub trait Searches {
 }
 
 impl SearchResult {
-    fn new(rownum: usize, line: String) -> SearchResult {
-        SearchResult { rownum, line }
+    fn new(rownum: usize, line: String, match_positions: Vec<(usize, usize)>) -> SearchResult {
+        SearchResult {
+            rownum,
+            line,
+            match_positions,
+        }
     }
 }
 
@@ -45,13 +50,38 @@ impl Searcher<'_> {
 
         for line in contents.lines() {
             if line.contains(self.query) {
-                let result = SearchResult::new(rownum, line.to_string());
+                let match_positions = self.find_match_positions(line, false);
+                let result = SearchResult::new(rownum, line.to_string(), match_positions);
                 results.push(result)
             }
             rownum += 1;
         }
 
         results
+    }
+
+    fn find_match_positions(&self, line: &str, case_insensitive: bool) -> Vec<(usize, usize)> {
+        let mut positions = Vec::new();
+        let search_line = if case_insensitive {
+            line.to_lowercase()
+        } else {
+            line.to_string()
+        };
+        let search_query = if case_insensitive {
+            self.query.to_lowercase()
+        } else {
+            self.query.to_string()
+        };
+
+        let mut start = 0;
+        while let Some(pos) = search_line[start..].find(&search_query) {
+            let match_start = start + pos;
+            let match_end = match_start + self.query.len();
+            positions.push((match_start, match_end));
+            start = match_end;
+        }
+
+        positions
     }
 
     fn insensitive_search<'a>(&'a self, contents: &'a str) -> Vec<SearchResult> {
@@ -61,7 +91,8 @@ impl Searcher<'_> {
 
         for line in contents.lines() {
             if line.to_lowercase().contains(&query) {
-                let result = SearchResult::new(rownum, line.to_string());
+                let match_positions = self.find_match_positions(line, true);
+                let result = SearchResult::new(rownum, line.to_string(), match_positions);
                 results.push(result)
             }
             rownum += 1;
@@ -76,6 +107,13 @@ impl ReSearcher {
         Ok(ReSearcher {
             pattern: Regex::new(pattern)?,
         })
+    }
+
+    fn find_regex_match_positions(&self, line: &str) -> Vec<(usize, usize)> {
+        self.pattern
+            .find_iter(line)
+            .map(|m| (m.start(), m.end()))
+            .collect()
     }
 }
 
@@ -96,7 +134,8 @@ impl Searches for Searcher<'_> {
         };
 
         if matches {
-            Some(SearchResult::new(rownum, line.to_string()))
+            let match_positions = self.find_match_positions(line, self.case_insensitive);
+            Some(SearchResult::new(rownum, line.to_string(), match_positions))
         } else {
             None
         }
@@ -110,7 +149,8 @@ impl Searches for ReSearcher {
 
         for line in contents.lines() {
             if self.pattern.is_match(line) {
-                let result = SearchResult::new(rownum, line.to_string());
+                let match_positions = self.find_regex_match_positions(line);
+                let result = SearchResult::new(rownum, line.to_string(), match_positions);
                 results.push(result)
             }
             rownum += 1;
@@ -121,7 +161,8 @@ impl Searches for ReSearcher {
 
     fn search_line(&self, line: &str, rownum: usize) -> Option<SearchResult> {
         if self.pattern.is_match(line) {
-            Some(SearchResult::new(rownum, line.to_string()))
+            let match_positions = self.find_regex_match_positions(line);
+            Some(SearchResult::new(rownum, line.to_string(), match_positions))
         } else {
             None
         }
@@ -139,7 +180,7 @@ mod tests {
         let searcher = Searcher::new("line", false);
 
         let observed_result = searcher.search(CONTENTS);
-        let expected_result = vec![SearchResult::new(1, "line one".to_string())];
+        let expected_result = vec![SearchResult::new(1, "line one".to_string(), vec![(0, 4)])];
 
         assert_eq!(observed_result, expected_result);
 
@@ -152,8 +193,8 @@ mod tests {
 
         let observed_result = searcher.search(CONTENTS);
         let expected_result = vec![
-            SearchResult::new(1, "line one".to_string()),
-            SearchResult::new(2, "LINE TWO".to_string()),
+            SearchResult::new(1, "line one".to_string(), vec![(0, 4)]),
+            SearchResult::new(2, "LINE TWO".to_string(), vec![(0, 4)]),
         ];
 
         assert_eq!(observed_result, expected_result);
@@ -166,7 +207,11 @@ mod tests {
         let re_searcher = ReSearcher::new("[a-z]+").expect("Valid regex pattern");
 
         let observed_result = re_searcher.search(CONTENTS);
-        let expected_result = vec![SearchResult::new(1, "line one".to_string())];
+        let expected_result = vec![SearchResult::new(
+            1,
+            "line one".to_string(),
+            vec![(0, 4), (5, 8)],
+        )];
 
         assert_eq!(observed_result, expected_result);
 

--- a/tests/error_handling_tests.rs
+++ b/tests/error_handling_tests.rs
@@ -46,9 +46,10 @@ fn test_search_files_handles_valid_search() -> Result<(), std::io::Error> {
     // Search for the term
     let searcher = Searcher::new("search", false);
     let paths = vec![test_file.clone()];
+    let mut output = finders::output::StandardOutput::new(finders::output::ColourMode::Never);
 
     // Should complete without panicking
-    let result = search_files(searcher, paths, false);
+    let result = search_files(searcher, paths, false, &mut output);
 
     // Clean up
     fs::remove_file(&test_file)?;
@@ -74,9 +75,10 @@ fn test_search_files_handles_binary_file() -> Result<(), std::io::Error> {
     // Try to search it - should handle gracefully with verbose=true
     let searcher = Searcher::new("test", false);
     let paths = vec![test_file.clone()];
+    let mut output = finders::output::StandardOutput::new(finders::output::ColourMode::Never);
 
     // Should not panic, even with invalid UTF-8
-    let result = search_files(searcher, paths, true);
+    let result = search_files(searcher, paths, true, &mut output);
 
     // Clean up
     fs::remove_file(&test_file)?;


### PR DESCRIPTION
Closes #17
Closes #22

---

## Summary
⚠️ **BREAKING CHANGES - MAJOR release v3.0.0**

Add UX enhancements with breaking output format changes:
- **#17 Colored Output**: Syntax highlighting for search results
- **#22 Multiple Output Modes**: Files-only, count, and JSON outputs

**Version:** 2.1.2 → 3.0.0 (MAJOR)

---

## ⚠️ Breaking Changes

### Output Format (BREAKING)

**What changed:**
```bash
# v2.x.x output:
   4: /path/to/file.rs                                      line content

# v3.0.0 output:
/path/to/file.rs:4: line content
```

**Impact:**
- Scripts parsing finder output WILL BREAK
- Line number position changed (moved to after filename)
- Fixed-width padding removed
- Path format changed (no quotes in file-only mode)

**Why MAJOR (3.0.0) instead of MINOR:**
- CLI output is effectively the API for a CLI tool
- This will break existing scripts that parse output
- Better to be conservative and clearly signal breaking change
- Matches ecosystem norms (ripgrep, fd treat output changes as major)

**Migration:**
- Update scripts to parse new `path:line: content` format
- Use `--json` mode for stable, machine-readable output going forward
- Test scripts with v3.0.0 before deploying to production

---

## 📋 CHECKPOINT 2: Interface Design Review

**Status:** Interface design complete - validating API ergonomics before implementation

**What to review:**
- ✅ CLI flag design and naming
- ✅ Color scheme choices
- ✅ Output format decisions
- ✅ Breaking changes acceptable (justifies v3.0.0)

**Interface documentation:** `docs/interface-v3.0.0.md`

---

## Interface Decisions

### Color Scheme
- **Paths**: Green
- **Line numbers**: Cyan
- **Matches**: White text on Magenta background
- **Auto-detect TTY** by default (colors in terminal, none when piped)

### CLI Flags
```bash
--colour / --no-colour     # Color control (UK spelling, no short flag)
-l, --files-with-matches   # Output only file paths
-c, --count                # Output match counts
--json                     # Structured JSON output
```

### Output Formats

**Standard (default with search):**
```
src/searcher.rs:42: This is a line with matching text
```

**Files-only (`-l`):**
```
src/searcher.rs
src/lib.rs
```

**Count (`-c`):**
```
src/searcher.rs:3
src/lib.rs:7
```

**JSON (`--json`):**
```json
[
  {
    "path": "src/searcher.rs",
    "matches": [
      {"line": 42, "content": "..."}
    ]
  }
]
```

### Environment Variables
- `NO_COLOR` - Disable colors (universal standard: https://no-color.org/)
- `CLICOLOR` - Enable/disable with TTY respect (BSD/macOS standard)
- `CLICOLOR_FORCE` - Force colors on, ignore TTY (https://bixense.com/clicolors/)

**Priority:** `--colour`/`--no-colour` > `NO_COLOR` > `CLICOLOR_FORCE` > `CLICOLOR` > auto-detect

---

## Implementation Plan

See `ROADMAP.md` for detailed plan:
1. Output abstraction layer (trait-based design)
2. Add color support with TTY detection
3. **Standardize output format (BREAKING)**
4. Add files-with-matches mode (-l)
5. Add count mode (-c)
6. Add JSON output (--json)
7. Add mutual exclusivity validation
8. **Update docs (ADR + CHANGELOG with breaking changes)**
9. Bump version to 3.0.0

**Commits:** 9 logical commits for incremental review

---

## Documentation Requirements

CHANGELOG must include:
- ✅ Prominent "BREAKING CHANGES" section
- ✅ Before/after examples of output format
- ✅ Migration guide for users with scripts
- ✅ Justification for v3.0.0 MAJOR bump
- ✅ Note that `--json` provides stable output format

---

## Next Steps

After interface approval:
1. Implement according to plan (9 commits)
2. Push at planned milestones for review
3. Keep PR in DRAFT during implementation
4. Mark ready after all milestones complete + self-validation

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
