### PR TITLE
Fix comparison benchmark parsing for v3.0.0 output format

### DIFF
--- a/benches/comparison_benchmarks.rs
+++ b/benches/comparison_benchmarks.rs
@@ -138,18 +138,15 @@ fn run_finder(dir: &PathBuf, pattern: &str, finder_bin: &Path) -> std::io::Resul
 
     let stdout = String::from_utf8_lossy(&output.stdout);
 
-    // finder outputs: "   4: /path/to/file.rs content..."
-    // Format: <line_num>: <path> <content>
-    // Extract unique file paths (all paths end with .rs in this benchmark)
+    // v3.0.0 format: "/path/to/file.rs:4: content"
+    // Format: <path>:<line_num>: <content>
+    // Extract unique file paths
     let mut files = std::collections::HashSet::new();
     for line in stdout.lines() {
-        // Find first colon (after line number)
-        if let Some(colon_pos) = line.find(": ") {
-            let after_colon = &line[colon_pos + 2..];
-            // Path ends with .rs - find the last occurrence
-            if let Some(rs_pos) = after_colon.rfind(".rs") {
-                // Include ".rs" in the path
-                let file_path = &after_colon[..rs_pos + 3];
+        // Split on first colon to get path
+        if let Some(colon_pos) = line.find(':') {
+            let file_path = &line[..colon_pos];
+            if !file_path.is_empty() {
                 files.insert(file_path.trim().to_string());
             }
         }


### PR DESCRIPTION
## Summary

Fixes comparison benchmark parsing to work with the v3.0.0 output format change.

## Problem

The v3.0.0 release changed the output format:
- **OLD (v2.x):** `   4: /path/to/file.rs                      content`
- **NEW (v3.0.0):** `/path/to/file.rs:4: content`

This broke the comparison benchmarks, causing them to report:
- find+grep: 50 files ✅
- ripgrep: 50 files ✅
- finder: **0 files** ❌

## Root Cause

The old parsing logic expected format `<line_num>: <path> <content>` and would:
1. Find first `: ` (expected after line number)
2. Extract everything after as path+content
3. Look for `.rs` to find path end

With the new format `/path/to/file.rs:4: content`:
1. First `: ` is found **after** the path (between line number and content)
2. Code tries to find `.rs` in `4: content` → fails
3. No files extracted → 0 results

## Fix

Simplified parsing to match new format:
```rust
// v3.0.0 format: "/path/to/file.rs:4: content"
for line in stdout.lines() {
    if let Some(colon_pos) = line.find(':') {
        let file_path = &line[..colon_pos];  // Extract path before first colon
        files.insert(file_path.trim().to_string());
    }
}
```

Much simpler and more robust than the old logic!

## Testing

Verified locally:
```bash
$ finder /tmp/test_finder -s "function" --no-colour
./test.rs:1: test function here

$ # Parsing extracts: "./test.rs" ✅
```

## Impact

- Unblocks v3.0.0 release validation
- Comparison benchmarks will now correctly validate finder results
- Simpler, more maintainable parsing logic

🤖 Generated with [Claude Code](https://claude.com/claude-code)