### PR TITLE
Fix macOS x86_64 release build runner

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
             target: x86_64-unknown-linux-gnu
             archive: tar.gz
             binary: finder
-          - os: macos-13
+          - os: macos-12
             target: x86_64-apple-darwin
             archive: tar.gz
             binary: finder


### PR DESCRIPTION
## Summary

Fixes the v3.0.0 release build by switching to a supported macOS runner.

## Problem

The v3.0.0 release build failed with error:
```
❌ The configuration 'macos-13-us-default' is not supported
```

The `macos-13` runner is no longer supported in some GitHub Actions configurations.

## Impact

This blocked the v3.0.0 release. Build results:
- ✅ Windows x86_64 - passed
- ✅ Linux x86_64 - passed
- ✅ macOS aarch64 (Apple Silicon) - passed
- ❌ macOS x86_64 (Intel) - runner config not supported

## Fix

Change release workflow to use `macos-12` instead of `macos-13` for Intel Mac builds.
`macos-12` is the last stable Intel macOS runner on GitHub Actions.

## Testing

After merge, will:
1. Delete and recreate v3.0.0 tag
2. Trigger release workflow with fixed runner configuration
3. Complete v3.0.0 release with all platform binaries

🤖 Generated with [Claude Code](https://claude.com/claude-code)