### PR TITLE
Use cross-compilation for macOS Intel builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,18 +25,22 @@ jobs:
             target: x86_64-unknown-linux-gnu
             archive: tar.gz
             binary: finder
-          - os: macos-12
+            cross_compile: false
+          - os: macos-latest
             target: x86_64-apple-darwin
             archive: tar.gz
             binary: finder
-          - os: macos-14
+            cross_compile: true
+          - os: macos-latest
             target: aarch64-apple-darwin
             archive: tar.gz
             binary: finder
+            cross_compile: false
           - os: windows-latest
             target: x86_64-pc-windows-msvc
             archive: zip
             binary: finder.exe
+            cross_compile: false
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -45,6 +49,10 @@ jobs:
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
+
+      - name: Install cross-compilation target
+        if: matrix.cross_compile
+        run: rustup target add ${{ matrix.target }}
 
       - name: Cache cargo registry
         uses: actions/cache@v4
@@ -64,17 +72,22 @@ jobs:
           path: target
           key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
 
+      # Skip tests when cross-compiling because we can't run x86_64 binaries on ARM64 runner
+      # Tests still run for native builds (Linux, Windows, macOS ARM64)
       - name: Run tests
+        if: ${{ !matrix.cross_compile }}
         run: cargo test --all-features -- --test-threads=1
 
+      # Always use --target flag for consistent paths: target/<target>/release/binary
       - name: Build release binary
-        run: cargo build --release
+        run: cargo build --release --target ${{ matrix.target }}
 
+      # Binary is always at: target/<target>/release/finder (or finder.exe)
       - name: Upload binary artifact
         uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.target }}-binary
-          path: target/release/${{ matrix.binary }}
+          path: target/${{ matrix.target }}/release/${{ matrix.binary }}
           if-no-files-found: error
 
   publish-release:


### PR DESCRIPTION
## Summary

Fixes the v3.0.0 release build by using cross-compilation for macOS Intel (x86_64) instead of deprecated Intel runners.

## Problem

GitHub has deprecated Intel macOS runners with very limited availability:
- `macos-13` - ❌ Not supported in some configurations
- `macos-12` - ❌ Hung in queue for 2+ hours

This blocked the v3.0.0 release as the Intel Mac build never started.

## Solution

Use **cross-compilation** from Apple Silicon (ARM64) to build Intel (x86_64) binaries:

**Before:**
```yaml
- os: macos-12          # Deprecated Intel runner (limited availability)
  target: x86_64-apple-darwin
```

**After:**
```yaml
- os: macos-latest      # ARM64 runner (excellent availability)
  target: x86_64-apple-darwin
  cross_compile: true   # Cross-compile from ARM64 to x86_64
```

## Changes

1. **Use `macos-latest` for both macOS targets:**
   - x86_64-apple-darwin: cross-compiled from ARM64
   - aarch64-apple-darwin: native ARM64 build

2. **Add cross-compilation support:**
   - Install target: `rustup target add x86_64-apple-darwin`
   - Build with target: `cargo build --release --target x86_64-apple-darwin`
   - Skip tests when cross-compiling (can't run x86_64 on ARM64)
   - Handle target subdirectory: `target/x86_64-apple-darwin/release/finder`

3. **Matrix flag for conditional logic:**
   - Added `cross_compile: true/false` to each matrix entry
   - Conditionally install target, skip tests, and adjust paths

## Benefits

- ✅ Fast, reliable builds (no more 2-hour queues)
- ✅ Both macOS targets use `macos-latest` (excellent availability)
- ✅ Rust cross-compilation is well-supported for macOS targets
- ✅ Produces identical binaries to native Intel builds

## Testing

After merge, will:
1. Delete and recreate v3.0.0 tag
2. Trigger release build with cross-compilation
3. Verify all 4 platform binaries build successfully

## Documentation

GitHub runners: https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources

🤖 Generated with [Claude Code](https://claude.com/claude-code)