### PR TITLE
Move benchmarks to /benchmarks subdirectory for GitHub Pages coordination

### DIFF
--- a/.github/workflows/comparison.yml
+++ b/.github/workflows/comparison.yml
@@ -286,10 +286,11 @@ jobs:
       - name: Update benchmark history
         run: |
           cd gh-pages-deploy
+          mkdir -p benchmarks
 
           # Create history.json if it doesn't exist
-          if [ ! -f history.json ]; then
-            echo "[]" > history.json
+          if [ ! -f benchmarks/history.json ]; then
+            echo "[]" > benchmarks/history.json
           fi
 
           # Append new entry to history
@@ -300,21 +301,21 @@ jobs:
           # Read existing history, append new entry, write back
           jq --arg ver "$VERSION" --arg date "$DATE" --arg ts "$TIMESTAMP" \
             '. += [{version: $ver, date: $date, timestamp: $ts, url: "./latest/report/index.html"}]' \
-            history.json > history_tmp.json
-          mv history_tmp.json history.json
+            benchmarks/history.json > benchmarks/history_tmp.json
+          mv benchmarks/history_tmp.json benchmarks/history.json
 
       - name: Copy Criterion HTML reports
         run: |
-          # Remove old latest/ directory
-          rm -rf gh-pages-deploy/latest
+          # Remove old benchmarks/latest/ directory
+          rm -rf gh-pages-deploy/benchmarks/latest
 
           # Copy new Criterion HTML output
-          mkdir -p gh-pages-deploy/latest
-          cp -r target/criterion/* gh-pages-deploy/latest/ || echo "No criterion output found"
+          mkdir -p gh-pages-deploy/benchmarks/latest
+          cp -r target/criterion/* gh-pages-deploy/benchmarks/latest/ || echo "No criterion output found"
 
       - name: Generate index page
         run: |
-          cd gh-pages-deploy
+          cd gh-pages-deploy/benchmarks
 
           cat > index.html << 'EOF'
           <!DOCTYPE html>
@@ -474,4 +475,4 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add -A
           git commit -m "Update benchmarks for ${{ steps.metrics.outputs.version }}" || echo "No changes to commit"
-          git push --force "https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git" gh-pages:gh-pages
+          git push --force-with-lease "https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git" gh-pages:gh-pages

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,9 @@ output.txt
 # Generated benchmark fixtures
 benches/fixtures/data/
 
+# mdBook build output
+docs/book/
+
 # Claude Code local settings
 .claude/
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ I live in the terminal and I got sick of typing `find . -type f -name "*.py" -ex
 
 ## 📚 Quick Links
 
-- **[Performance Benchmarks](https://ydkadri.github.io/finders/)** - See how it compares
+- **[Performance Benchmarks](https://ydkadri.github.io/finders/benchmarks/)** - See how it compares
 - **[Contributing Guide](CONTRIBUTING.md)** - Help make it better
 - **[Changelog](CHANGELOG.md)** - What's new
 - **[Architecture Decisions](docs/adr/)** - Why things work the way they do
@@ -252,7 +252,7 @@ Key benchmark categories:
 - **searcher_search_content**: Tests multi-line content searching
 - **file_finder**: Tests file discovery with and without patterns
 
-**Comparison Benchmarks**: See how `finder` performs against `find+grep` and `ripgrep` at [ydkadri.github.io/finders](https://ydkadri.github.io/finders/)
+**Comparison Benchmarks**: See how `finder` performs against `find+grep` and `ripgrep` at [ydkadri.github.io/finders/benchmarks](https://ydkadri.github.io/finders/benchmarks/)
 
 ### Performance Summary (as of 2026-04-05)
 


### PR DESCRIPTION
## Summary

Moves benchmark deployment from root to `/benchmarks` subdirectory to allow documentation site (mdBook) to coexist at root of GitHub Pages.

## Changes

**Workflow updates:**
- Place Criterion HTML reports in `benchmarks/latest/` instead of `latest/`
- Move `history.json` to `benchmarks/history.json`
- Generate benchmark index.html inside `benchmarks/` directory
- Preserve existing gh-pages content (won't overwrite mdBook docs at root)
- Changed `--force` to `--force-with-lease` for safer pushes

**Documentation updates:**
- Updated README benchmark links: `ydkadri.github.io/finders/` → `ydkadri.github.io/finders/benchmarks/`
- Added `docs/book/` to .gitignore (mdBook build output)

## Result After Both PRs Merge

- **Documentation**: https://ydkadri.github.io/finders/ (root)
- **Benchmarks**: https://ydkadri.github.io/finders/benchmarks/ (subdirectory)

Both workflows can deploy independently without conflicts.

## Testing

This should be merged **before** PR #76 (mdBook setup) to avoid temporarily breaking the existing benchmark site. Merge order:
1. Merge this PR first → benchmarks move to /benchmarks
2. Then merge #76 → docs deploy to root

Related to #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)