### PR TITLE
Fix comparison workflow to preserve gh-pages content

### DIFF
--- a/.github/workflows/comparison.yml
+++ b/.github/workflows/comparison.yml
@@ -265,23 +265,23 @@ jobs:
 
       - name: Setup gh-pages deployment directory
         run: |
-          # Remove any existing directory and start fresh
+          # Clone existing gh-pages branch to preserve docs and other content
           rm -rf gh-pages-deploy
-          mkdir -p gh-pages-deploy
-          cd gh-pages-deploy
 
-          # Initialize git repo
-          git init
+          git clone --branch gh-pages --single-branch \
+            "https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git" \
+            gh-pages-deploy 2>/dev/null || {
+            # Branch doesn't exist yet, create empty directory
+            mkdir -p gh-pages-deploy
+            cd gh-pages-deploy
+            git init
+            git checkout -b gh-pages
+            git remote add origin "https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git"
+          }
+
+          cd gh-pages-deploy
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git checkout -b gh-pages
-
-          # Try to fetch existing gh-pages content if it exists
-          git remote add origin "https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git"
-          git fetch origin gh-pages:gh-pages 2>/dev/null || echo "No existing gh-pages branch, will create new one"
-
-          # If branch exists, check it out; otherwise we already have an empty gh-pages
-          git checkout gh-pages 2>/dev/null || echo "Starting with new gh-pages branch"
 
       - name: Update benchmark history
         run: |


### PR DESCRIPTION
## Problem

The comparison benchmark workflow fails when trying to push to gh-pages with error:
```
! [rejected] gh-pages -> gh-pages (stale info)
```

**Root cause:** The workflow was:
1. Creating a fresh `git init` repo
2. Creating a new branch `gh-pages`
3. Trying to fetch existing content
4. This created a **root commit** that conflicted with the existing gh-pages content from the docs deployment

## Solution

Clone the existing gh-pages branch directly instead of init + fetch:

```bash
git clone --branch gh-pages --single-branch ... gh-pages-deploy
```

This:
- ✅ Preserves all existing content (docs at root)
- ✅ Allows updating just the `/benchmarks` directory  
- ✅ No merge conflicts
- ✅ Works whether gh-pages exists or not (fallback to init)

## Testing

The fix allows both workflows to coexist:
- Docs workflow deploys to root: https://ydkadri.github.io/finders/
- Benchmark workflow deploys to /benchmarks: https://ydkadri.github.io/finders/benchmarks/

After merging, we can manually re-run the failed workflow to deploy benchmarks.