### PR TITLE
Fix comparison workflow: use --force instead of --force-with-lease

### DIFF
--- a/.github/workflows/comparison.yml
+++ b/.github/workflows/comparison.yml
@@ -475,4 +475,4 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add -A
           git commit -m "Update benchmarks for ${{ steps.metrics.outputs.version }}" || echo "No changes to commit"
-          git push --force-with-lease "https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git" gh-pages:gh-pages
+          git push --force "https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git" gh-pages:gh-pages

--- a/src/searcher.rs
+++ b/src/searcher.rs
@@ -46,15 +46,13 @@ impl Searcher<'_> {
 
     fn sensitive_search<'a>(&'a self, contents: &'a str) -> Vec<SearchResult> {
         let mut results = Vec::new();
-        let mut rownum = 1;
 
-        for line in contents.lines() {
+        for (rownum, line) in (1..).zip(contents.lines()) {
             if line.contains(self.query) {
                 let match_positions = self.find_match_positions(line, false);
                 let result = SearchResult::new(rownum, line.to_string(), match_positions);
                 results.push(result)
             }
-            rownum += 1;
         }
 
         results
@@ -87,15 +85,13 @@ impl Searcher<'_> {
     fn insensitive_search<'a>(&'a self, contents: &'a str) -> Vec<SearchResult> {
         let mut results = Vec::new();
         let query = self.query.to_lowercase();
-        let mut rownum = 1;
 
-        for line in contents.lines() {
+        for (rownum, line) in (1..).zip(contents.lines()) {
             if line.to_lowercase().contains(&query) {
                 let match_positions = self.find_match_positions(line, true);
                 let result = SearchResult::new(rownum, line.to_string(), match_positions);
                 results.push(result)
             }
-            rownum += 1;
         }
 
         results
@@ -145,15 +141,13 @@ impl Searches for Searcher<'_> {
 impl Searches for ReSearcher {
     fn search<'a>(&'a self, contents: &'a str) -> Vec<SearchResult> {
         let mut results = Vec::new();
-        let mut rownum = 1;
 
-        for line in contents.lines() {
+        for (rownum, line) in (1..).zip(contents.lines()) {
             if self.pattern.is_match(line) {
                 let match_positions = self.find_regex_match_positions(line);
                 let result = SearchResult::new(rownum, line.to_string(), match_positions);
                 results.push(result)
             }
-            rownum += 1;
         }
 
         results


### PR DESCRIPTION
## Problem

The comparison benchmarks workflow fails with stale info error.

`--force-with-lease` fails because the gh-pages branch may be updated between clone and push.

## Solution

Use `--force` instead. This is safe because:
- gh-pages branch is automation-only (no human edits)
- Docs use GitHub Actions artifacts, not gh-pages branch
- Workflow always starts fresh with clone
- Want to replace entire content anyway

## Testing

After merge, manually trigger comparison workflow to verify it works.