### PR TITLE
Fix GitHub Pages deployment for benchmarks

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,17 +14,13 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
-  pages: write
-  id-token: write
-
-concurrency:
-  group: "pages"
-  cancel-in-progress: false
+  contents: write
 
 jobs:
-  build:
+  deploy:
     runs-on: ubuntu-latest
+    # Only deploy on push to main, not on PRs
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -39,20 +35,11 @@ jobs:
           cd docs
           mdbook build
 
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
-        with:
-          path: 'docs/book'
-
-  deploy:
-    # Only deploy on push to main, not on PRs
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
-    needs: build
-    steps:
       - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./docs/book
+          publish_branch: gh-pages
+          keep_files: true
+          destination_dir: .


### PR DESCRIPTION
## Problem

Benchmarks page at https://ydkadri.github.io/finders/benchmarks/ returns 404.

**Root cause:** GitHub Pages is configured for "workflow" deployment (Actions artifacts), but comparison benchmarks workflow pushes to gh-pages branch which isn't being served.

## Solution

Switch GitHub Pages to serve from gh-pages branch instead of Actions artifacts.

### Changes

1. **Updated `.github/workflows/docs.yml`:**
   - Replace `actions/upload-pages-artifact` + `actions/deploy-pages` with `peaceiris/actions-gh-pages`
   - Deploy directly to gh-pages branch at root
   - Use `keep_files: true` to preserve benchmark files

2. **Cleaned up gh-pages branch:**
   - Added `.nojekyll` to root (already pushed)
   - Removed old benchmark files at root
   - Structure is now:
     - `/` (root) → documentation (from docs.yml)
     - `/benchmarks/` → benchmarks (from comparison.yml)

### After Merge

**Manual step required:** Change GitHub Pages settings:
1. Go to Settings → Pages
2. Change "Build and deployment" source from "GitHub Actions" to "Deploy from a branch"
3. Select branch: `gh-pages`, folder: `/ (root)`

Then both workflows will deploy to the same branch:
- docs.yml deploys to root
- comparison.yml deploys to /benchmarks subdirectory

### Testing

After merge and settings change:
- Docs: https://ydkadri.github.io/finders/
- Benchmarks: https://ydkadri.github.io/finders/benchmarks/

🤖 Generated by Claude Code