### PR TITLE
Fix benchmark report to handle old history format

### DIFF
--- a/.github/scripts/generate_benchmark_report.py
+++ b/.github/scripts/generate_benchmark_report.py
@@ -84,7 +84,7 @@ def prepare_summary_data(history: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
 
         # Calculate changes if we have previous data
         changes = {}
-        if previous:
+        if previous and "results" in previous:
             prev_result = next((r for r in previous["results"] if r["scenario"] == scenario), None)
             if prev_result:
                 if finder is not None and prev_result.get("finder"):
@@ -124,6 +124,9 @@ def prepare_trend_data(history: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
         # Collect finder times across history for this scenario
         finder_trend = []
         for entry in recent:
+            # Skip entries without results (old format)
+            if "results" not in entry:
+                continue
             scenario_result = next((r for r in entry["results"] if r["scenario"] == scenario), None)
             if scenario_result and scenario_result.get("finder"):
                 finder_trend.append(scenario_result["finder"])


### PR DESCRIPTION
## Fix

Benchmark workflow was failing because the old history.json entry lacks the `results` field:

```json
{
  "version": "dev-20260420-224504",
  "date": "2026-04-20",
  "timestamp": "2026-04-20T22:45:04Z",
  "url": "./latest/report/index.html"
}
```

New format includes `results`:
```json
{
  "version": "v3.0.1",
  "results": [...]
}
```

## Changes

Added safety checks in two places:
1. `prepare_summary_data()` - check `if previous and "results" in previous`
2. `prepare_trend_data()` - skip entries without `results`

Now gracefully handles mixed old/new format entries.

## Testing

Tested with mixed history containing both formats - works correctly.

Fixes #24696383347 workflow failure

🤖 Generated by Claude Code