### PR TITLE
Fix function ordering in file_finder (#54)

### DIFF
--- a/src/file_finder/mod.rs
+++ b/src/file_finder/mod.rs
@@ -14,6 +14,13 @@ impl Finder<'_> {
         Ok(Finder { path })
     }
 
+    pub fn find(&self, query: Option<&str>) -> Vec<PathBuf> {
+        match query {
+            Some(q) => self.filtered_find(q),
+            None => self.unfiltered_find(),
+        }
+    }
+
     fn find_internal(&self) -> IntoIter {
         WalkDir::new(self.path).follow_links(true).into_iter()
     }
@@ -83,13 +90,6 @@ impl Finder<'_> {
         }
 
         results
-    }
-
-    pub fn find(&self, query: Option<&str>) -> Vec<PathBuf> {
-        match query {
-            Some(q) => self.filtered_find(q),
-            None => self.unfiltered_find(),
-        }
     }
 }
 


### PR DESCRIPTION
## Changes

Reorders functions in `Finder` impl to follow Rust style guide:

**Before:**
```
new() → find_internal() → unfiltered_find() → filtered_find() → find()
```

**After:**
```
new() → find() → find_internal() → unfiltered_find() → filtered_find()
```

**Rust style guide:** Constructor first, public methods, then private helpers.

## Testing

- ✅ All tests pass (`cargo test --lib -- --test-threads=1`)
- ✅ No behavior changes
- ✅ Pure style/readability improvement

## Related

Closes #54

Part of project structure review findings.

🤖 Generated by Claude Code