### PR TITLE
Add convenience re-exports to lib.rs (#91)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,13 @@ pub mod file_finder;
 pub mod output;
 pub mod searcher;
 
+// Re-export commonly used types for convenience
+pub use file_finder::Finder;
+pub use output::{
+    ColourMode, CountOutput, FilesOnlyOutput, JsonOutput, Outputs, SearchMatch, StandardOutput,
+};
+pub use searcher::{ReSearcher, SearchResult, Searcher, Searches};
+
 const CHUNK_SIZE: usize = 8192; // 8KB chunks for reading files
 
 pub fn search_files(


### PR DESCRIPTION
## Changes

Adds `pub use` re-exports for commonly used types in `lib.rs`.

**Before:**
```rust
use finders::file_finder::Finder;
use finders::searcher::Searcher;
use finders::output::StandardOutput;
```

**After:**
```rust
use finders::{Finder, Searcher, StandardOutput};
```

## Benefits

- **Better ergonomics:** Shorter, cleaner imports
- **No breaking changes:** Module paths still work
- **Follows Rust conventions:** Common pattern in ecosystem (serde, tokio, etc.)

## Types Re-exported

- `Finder` - Main file finder struct
- `Searcher`, `ReSearcher` - Search implementations  
- `Searches`, `SearchResult` - Search trait and results
- `Outputs`, `SearchMatch` - Output trait and data
- `ColourMode` - Color configuration
- All output implementations: `StandardOutput`, `JsonOutput`, `CountOutput`, `FilesOnlyOutput`

## Testing

- ✅ All tests pass
- ✅ No behavior changes
- ✅ Pure API ergonomics improvement

Closes #91

🤖 Generated by Claude Code