### PR TITLE
docs: Add ADRs for GitHub Pages and benchmark reports

### DIFF
--- a/docs/adr/0003-github-pages-deployment-strategy.md
+++ b/docs/adr/0003-github-pages-deployment-strategy.md
@@ -1,0 +1,131 @@
+# 0003. GitHub Pages Deployment Strategy
+
+Date: 2026-04-20
+
+## Status
+
+Accepted
+
+## Context
+
+FindeRS maintains two types of generated content that need to be hosted on GitHub Pages:
+
+1. **Documentation** (rustdoc) - Generated from Rust source code
+2. **Benchmarks** - Comparison benchmarks run on each release
+
+Initially, we attempted to use GitHub Actions artifacts for documentation deployment while the comparison benchmarks workflow pushed directly to the `gh-pages` branch at `/benchmarks/`. This created a conflict: GitHub Pages was configured for "workflow" deployment (Actions artifacts), but the benchmarks were being pushed to a branch that wasn't being served, resulting in a 404 at https://ydkadri.github.io/finders/benchmarks/.
+
+**The core problem:** GitHub Pages only supports one deployment source - either Actions artifacts OR a branch, but not both simultaneously.
+
+## Decision
+
+We will use **branch-based deployment** with the `gh-pages` branch as the single source for all GitHub Pages content. Both documentation and benchmarks will be pushed to this branch by their respective workflows.
+
+### Implementation
+
+1. **Documentation workflow** (`.github/workflows/docs.yml`):
+   - Switched from `actions/upload-pages-artifact` + `actions/deploy-pages` to `peaceiris/actions-gh-pages@v3`
+   - Deploys rustdoc output to root of `gh-pages` branch
+   - Uses `keep_files: true` to preserve existing benchmark files
+
+2. **Comparison workflow** (`.github/workflows/comparison.yml`):
+   - Already pushes to `gh-pages` branch at `/benchmarks/` subdirectory
+   - Changed from `--force-with-lease` to `--force` for push (see consequences)
+
+3. **GitHub Pages settings** (manual):
+   - Changed from "GitHub Actions" source to "Deploy from a branch"
+   - Selected `gh-pages` branch, `/ (root)` folder
+
+### Directory Structure
+
+```
+gh-pages branch:
+├── .nojekyll              # Disable Jekyll processing
+├── index.html             # Documentation root
+├── [rustdoc files]        # All documentation
+└── benchmarks/            # Benchmark reports
+    ├── index.html
+    ├── history.json
+    └── latest/
+        └── report/        # Criterion reports
+```
+
+## Consequences
+
+### Positive
+
+- **Single source of truth**: All content served from one branch eliminates deployment conflicts
+- **Consistent deployment**: Both workflows use similar patterns (push to gh-pages)
+- **File preservation**: Documentation and benchmarks coexist without overwriting each other
+- **Standard GitHub Pages**: Uses well-established branch-based deployment pattern
+
+### Negative
+
+- **Manual configuration required**: GitHub Pages source setting must be changed via web UI after merge
+- **Force push required**: Using `--force` instead of `--force-with-lease` loses safety check
+  - Acceptable because `gh-pages` is automation-only (no human edits)
+  - Necessary because branch may be updated between workflows cloning and pushing
+- **Workflow coordination**: Two workflows must coordinate to avoid conflicts
+  - Mitigated by `keep_files: true` preserving non-overlapping content
+
+### Neutral
+
+- **Branch vs artifact deployment**: Trade-off between safety (artifacts) and flexibility (branch)
+- **Third-party action dependency**: Now depend on `peaceiris/actions-gh-pages` for docs deployment
+
+## Alternatives Considered
+
+### Alternative 1: Actions Artifacts for Both
+
+**Description**: Convert benchmarks workflow to also use Actions artifacts deployment
+
+**Pros**:
+- More "modern" GitHub Pages pattern
+- Better safety (no force pushes)
+- Official GitHub action support
+
+**Cons**:
+- Would require significant restructuring of comparison workflow
+- Harder to maintain historical benchmark data (artifacts are ephemeral by nature)
+- More complex: need to download previous history, update, re-upload
+- Workflow runs would need special Pages deployment permissions
+
+**Why not chosen**: Branch-based deployment better fits our benchmark history requirements. The comparison workflow already pushes to gh-pages successfully.
+
+### Alternative 2: Separate GitHub Pages Sites
+
+**Description**: Host documentation and benchmarks on separate URLs (e.g., separate repos or subdomains)
+
+**Pros**:
+- Complete isolation between content types
+- No coordination needed
+
+**Cons**:
+- More complex for users to discover both resources
+- Would require additional repository or configuration
+- Unnecessarily complex for our needs
+
+**Why not chosen**: Overengineering for a personal project. Single site with subdirectories is simpler.
+
+### Alternative 3: Documentation-Only on Pages
+
+**Description**: Remove benchmarks from GitHub Pages entirely, serve elsewhere or not at all
+
+**Pros**:
+- Eliminates deployment coordination issues
+- Could use simpler docs.yml workflow
+
+**Cons**:
+- Loses public benchmark visibility
+- Benchmarks are valuable for transparency and tracking performance
+- Would need alternative hosting solution
+
+**Why not chosen**: Public benchmarks are a feature, not a problem to eliminate.
+
+## References
+
+- [PR #85: Fix GitHub Pages deployment for benchmarks](https://github.com/ydkadri/finders/pull/85)
+- [PR #82: Fix comparison workflow: use --force instead of --force-with-lease](https://github.com/ydkadri/finders/pull/82)
+- [Issue: Benchmarks 404](https://github.com/ydkadri/finders/issues/79) (if exists)
+- [GitHub Pages documentation](https://docs.github.com/en/pages/getting-started-with-github-pages/configuring-a-publishing-source-for-your-github-pages-site)
+- [peaceiris/actions-gh-pages documentation](https://github.com/peaceiris/actions-gh-pages)

--- a/docs/adr/0004-benchmark-report-generation-with-historical-trends.md
+++ b/docs/adr/0004-benchmark-report-generation-with-historical-trends.md
@@ -1,0 +1,204 @@
+# 0004. Benchmark Report Generation with Historical Trends
+
+Date: 2026-04-20
+
+## Status
+
+Accepted
+
+## Context
+
+The comparison benchmarks workflow originally generated a basic HTML page showing only the latest benchmark results. The page had several limitations:
+
+1. **No historical context**: Only showed current run, no performance trends over time
+2. **Static HTML in workflow**: 150+ line heredoc embedded in YAML workflow file
+3. **Limited metadata**: `history.json` stored only version/date/URL, not actual results
+4. **Poor maintainability**: HTML/CSS mixed with workflow logic, hard to modify
+5. **No visual indicators**: Results displayed as plain numbers without change indicators
+
+Users (and future maintainers) needed:
+- **Trend visibility**: Is performance improving or regressing over releases?
+- **Change detection**: Quick visual feedback on performance deltas
+- **Maintainable reports**: Easier to modify templates without touching workflow YAML
+- **Historical data**: Ability to analyze performance patterns across releases
+
+## Decision
+
+We will generate custom HTML benchmark reports using **Python with Jinja2 templating** and store **full benchmark results** in the history file to enable historical trend analysis.
+
+### Architecture
+
+```
+Workflow (comparison.yml)
+    ↓
+1. Run benchmarks (criterion)
+    ↓
+2. Parse finders-benchmarks.json → results array
+    ↓
+3. Update history.json (store full results + metadata)
+    ↓
+4. Python script: generate_benchmark_report.py
+    ↓
+5. Render Jinja2 template → index.html
+    ↓
+6. Deploy to gh-pages/benchmarks/
+```
+
+### Components
+
+1. **History storage** (`.github/workflows/comparison.yml`):
+   ```json
+   {
+     "version": "v3.0.1",
+     "date": "2026-04-21",
+     "timestamp": "2026-04-21T00:00:00Z",
+     "results": [
+       {"scenario": "small_common", "pattern": "common", "size": "Small (~100 files)", 
+        "finder": 2, "find_grep": 86, "ripgrep": 5},
+       ...
+     ]
+   }
+   ```
+   Previously stored only `{version, date, url}` metadata.
+
+2. **Report generator** (`.github/scripts/generate_benchmark_report.py`):
+   - Reads `benchmarks/history.json`
+   - Calculates performance changes (±5% thresholds for better/worse/neutral)
+   - Prepares data for summary table and trend visualizations
+   - Renders Jinja2 templates with data
+
+3. **Templates** (`.github/templates/`):
+   - `benchmark_report.html` - Jinja2 template for HTML structure
+   - `benchmark_report.css` - Separate stylesheet
+   - Clean separation of presentation from logic
+
+### Features
+
+**Summary Table**:
+- All 6 scenarios (3 sizes × 2 patterns)
+- Comparison: finder vs find+grep vs ripgrep
+- Color-coded change indicators:
+  - 🟢 Green ↓: >5% faster (better)
+  - ⚪ Gray →: Within ±5% (similar)
+  - 🔴 Red ↑: >5% slower (worse)
+
+**Historical Trends**:
+- Tracks last 5 benchmark runs
+- Mini sparkline bar charts for visual trends
+- Percentage change from oldest to latest in window
+- Identifies performance regressions early
+
+**Graceful Degradation**:
+- Handles mixed old/new history format
+- Skips entries without `results` field
+- First run shows single entry (no trends yet)
+- Builds up history over subsequent runs
+
+## Consequences
+
+### Positive
+
+- **Better visibility**: Performance trends visible at a glance with color coding
+- **Maintainability**: HTML templates separate from workflow logic
+- **Extensibility**: Easy to add new visualizations or metrics
+- **Historical analysis**: Full result storage enables future data analysis
+- **Professional presentation**: Modern, clean UI improves project credibility
+- **Early detection**: Regressions spotted immediately with color indicators
+- **Template reusability**: Jinja2 templates can be modified without workflow changes
+
+### Negative
+
+- **Additional dependency**: Requires Python with Jinja2 in CI environment
+  - Mitigation: GitHub Actions runners include Python by default
+  - Only `pip install jinja2` needed
+- **Storage overhead**: History file grows with each benchmark run
+  - ~500 bytes per entry × max ~20-30 relevant entries = ~15KB total (negligible)
+- **Migration burden**: Old history entries lack `results` field
+  - Mitigation: Code handles mixed format gracefully
+  - Old entries don't show trends but don't break reports
+- **Maintenance surface**: Additional files to maintain (Python script, templates)
+  - Trade-off: Separation improves maintainability despite file count
+
+### Neutral
+
+- **Python in CI**: Workflow now runs Python script vs pure bash/jq
+  - Python + Jinja2 more maintainable than heredoc approach
+- **Report generation time**: Adds ~1-2 seconds to workflow
+  - Negligible compared to benchmark execution time (~2-3 minutes)
+
+## Alternatives Considered
+
+### Alternative 1: Continue with Static HTML Heredoc
+
+**Description**: Keep the existing 150+ line heredoc in workflow YAML
+
+**Pros**:
+- No new dependencies
+- Self-contained in workflow
+- Simple to understand
+
+**Cons**:
+- Hard to maintain (HTML/CSS/data mixed in YAML)
+- No historical trends possible
+- Poor separation of concerns
+- Difficult to test changes locally
+
+**Why not chosen**: Maintainability and feature limitations. The heredoc approach was already becoming unwieldy at 150 lines, and adding trends would make it worse.
+
+### Alternative 2: Static Site Generator (Jekyll, Hugo, etc.)
+
+**Description**: Use a full static site generator for benchmark pages
+
+**Pros**:
+- Rich ecosystem of themes and plugins
+- Professional-looking output
+- Built-in templating
+
+**Cons**:
+- Significant overhead for simple benchmark page
+- Complex configuration
+- Harder to customize for specific needs
+- Adds substantial dependencies
+
+**Why not chosen**: Overengineering. Our needs are simple: one page with a table and some charts. A full SSG is excessive.
+
+### Alternative 3: JavaScript-Based Rendering
+
+**Description**: Store data as JSON, use client-side JS to render charts/tables
+
+**Pros**:
+- Interactive visualizations possible
+- Lightweight server-side (just serve JSON)
+- Modern web approach
+
+**Cons**:
+- Requires JavaScript enabled (accessibility concern)
+- More complex for simple tabular data
+- Harder to maintain
+- No benefit for our static content
+
+**Why not chosen**: Server-side rendering is simpler and more accessible. We don't need interactivity for basic performance tables.
+
+### Alternative 4: Store Only Aggregates, Not Full Results
+
+**Description**: Store summary statistics rather than complete result arrays
+
+**Pros**:
+- Smaller history file
+- Faster processing
+
+**Cons**:
+- Limits future analysis options
+- Can't recalculate aggregates if methodology changes
+- Loss of granularity
+
+**Why not chosen**: Storage is cheap, flexibility is valuable. Full results enable richer future analysis without re-running old benchmarks.
+
+## References
+
+- [PR #86: Add custom benchmark reports with historical trends](https://github.com/ydkadri/finders/pull/86)
+- [PR #88: Fix benchmark report to handle old history format](https://github.com/ydkadri/finders/pull/88)
+- [Jinja2 documentation](https://jinja.palletsprojects.com/)
+- [Criterion.rs](https://github.com/bheisler/criterion.rs) - Rust benchmarking framework used
+- [benchmark history.json](https://gist.github.com/ydkadri/5616380737bada94e84764d02b816b38) - Live history data
+- [Live benchmark page](https://ydkadri.github.io/finders/benchmarks/)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -44,6 +44,9 @@ ADRs are **encouraged but not required**. Consider writing an ADR for:
 
 - [Template](template.md) - ADR template for new decisions
 - [0001: Comparison Benchmark Architecture](0001-comparison-benchmark-architecture.md) - Release-based benchmarks with GitHub Pages deployment
+- [0002: Output Abstraction and v3 Breaking Changes](0002-output-abstraction-and-v3-breaking-changes.md) - Output trait for flexible result formatting
+- [0003: GitHub Pages Deployment Strategy](0003-github-pages-deployment-strategy.md) - Branch-based deployment for docs and benchmarks
+- [0004: Benchmark Report Generation with Historical Trends](0004-benchmark-report-generation-with-historical-trends.md) - Custom HTML reports with Jinja2 templating
 
 ## Status Workflow
 


### PR DESCRIPTION
## Summary

Adds two Architecture Decision Records documenting recent infrastructure decisions.

## ADRs Added

### ADR 0003: GitHub Pages Deployment Strategy

Documents the switch from GitHub Actions artifacts to branch-based deployment for GitHub Pages.

**Key decisions:**
- Use `gh-pages` branch as single source for all Pages content
- Both docs.yml and comparison.yml push to this branch
- Documentation at root, benchmarks at `/benchmarks/`
- Use `--force` push for automation (safe because branch is automation-only)

**Covers:**
- Why we couldn't use artifacts + branch simultaneously
- Trade-offs of branch-based vs artifact deployment
- Alternatives considered (separate sites, docs-only, etc.)

### ADR 0004: Benchmark Report Generation with Historical Trends

Documents the custom HTML benchmark report generator using Python and Jinja2.

**Key decisions:**
- Store full benchmark results in history.json (not just metadata)
- Use Python + Jinja2 for report generation
- Calculate performance deltas with ±5% thresholds
- Show trends over last 5 runs with sparklines

**Covers:**
- Why we moved from static HTML heredoc to templating
- Benefits of historical trend tracking
- Alternatives considered (SSGs, JavaScript rendering, etc.)

## Related PRs

- #82 - Fix comparison workflow force push
- #85 - Switch Pages to branch deployment
- #86 - Add custom benchmark reports
- #88 - Fix history format handling

## Why These ADRs

Per CLAUDE.md guidance, ADRs are appropriate for:
- ✅ Tool selection (Jinja2 for templating)
- ✅ File formats and data structures (history.json format)
- ✅ CI/deployment strategy changes

These decisions affect how we maintain and deploy the project going forward, so documenting the rationale helps future maintainers (including ourselves).

🤖 Generated with [Claude Code](https://claude.com/claude-code)