### PR TITLE
Fix auto-tag workflow to trigger releases automatically

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -145,10 +145,7 @@ jobs:
 
       - name: Create and push tag
         if: steps.tag-check.outputs.exists == 'false'
-        env:
-          # Use PAT to trigger release workflow
-          # GitHub's default GITHUB_TOKEN doesn't trigger other workflows
-          GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}
+        id: create-tag
         run: |
           TAG_NAME="v${{ steps.version.outputs.version }}"
           echo "Creating tag $TAG_NAME"
@@ -159,9 +156,34 @@ jobs:
           git tag -a "$TAG_NAME" -m "Release $TAG_NAME"
 
           # Push using PAT to trigger release workflow
-          git push https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}.git "$TAG_NAME"
+          # Using PAT_TOKEN instead of GITHUB_TOKEN to trigger downstream workflows
+          git push https://x-access-token:${{ secrets.PAT_TOKEN }}@github.com/${{ github.repository }}.git "$TAG_NAME"
 
           echo "✅ Created and pushed tag $TAG_NAME"
+          echo "tag=$TAG_NAME" >> $GITHUB_OUTPUT
+
+      - name: Trigger release workflow
+        if: steps.tag-check.outputs.exists == 'false'
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.PAT_TOKEN }}
+          script: |
+            // Trigger the release workflow manually as a fallback
+            // PATs from the same account don't always trigger workflows on tag push
+            const tag = '${{ steps.create-tag.outputs.tag }}';
+            console.log(`Triggering release workflow for ${tag}`);
+
+            await github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'release.yml',
+              ref: 'main',
+              inputs: {
+                tag: tag
+              }
+            });
+
+            console.log(`✅ Release workflow triggered for ${tag}`);
 
       - name: Log result
         if: always()
@@ -169,6 +191,7 @@ jobs:
           echo "Auto-tag result:"
           echo "  Version: ${{ steps.version.outputs.version }}"
           echo "  Tag exists: ${{ steps.tag-check.outputs.exists }}"
+          echo "  Tag created: ${{ steps.create-tag.outputs.tag || 'N/A' }}"
 
   security-scheduled:
     name: Security Audit (Scheduled)


### PR DESCRIPTION
## Summary

Fix the auto-tag workflow to automatically trigger the release workflow when a new version is detected.

## Problem

The Main Branch workflow was already using `PAT_TOKEN` to push tags, but the Release workflow still wasn't triggering automatically. This is because GitHub doesn't trigger workflows from tags pushed by PATs from the same account as a security measure to prevent recursive workflow triggers.

## Solution

Added an explicit workflow dispatch step that triggers the release workflow immediately after creating and pushing the tag. This ensures releases are fully automated without requiring manual intervention.

## Changes

- Use `PAT_TOKEN` directly in git push command (no intermediate env var)
- Add `Trigger release workflow` step that explicitly dispatches the release workflow
- Output tag name for verification in logs

## How It Works

1. Version bump detected in `Cargo.toml`
2. Tag created and pushed using PAT_TOKEN
3. Release workflow explicitly triggered via GitHub API with the tag name
4. Release builds, publishes binaries, and publishes to crates.io automatically

## Testing

- [ ] Will be tested on next version bump (v3.0.3 or later)
- Workflow syntax validated locally

## Breaking Changes

None - this only affects the automation, not the release process itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)