### PR TITLE
API: Add consistent verbose flag to Finder::find() (part 2/3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Only accessed internally within `Finder` methods
   - No external impact (field only accessed in internal tests)
 
+- **API consistency:** Add consistent verbose parameter to `Finder::find()`
+  - Method signature: `find(&self, query: Option<&str>, verbose: bool)`
+  - All warning messages now controlled by verbose flag
+  - CLI passes user's verbose flag to file finder
+  - Benchmarks and tests use `verbose=false` for clean output
+
 ## [3.0.2] - 2026-04-21
 
 ### Changed

--- a/benches/search_benchmarks.rs
+++ b/benches/search_benchmarks.rs
@@ -78,14 +78,14 @@ fn bench_file_finder(c: &mut Criterion) {
     group.bench_function("find_all_files", |b| {
         b.iter(|| {
             let finder = file_finder::Finder::new(Some(black_box(temp_dir_str))).unwrap();
-            finder.find(None)
+            finder.find(None, false) // verbose=false for benchmarks
         })
     });
 
     group.bench_function("find_with_pattern", |b| {
         b.iter(|| {
             let finder = file_finder::Finder::new(Some(black_box(temp_dir_str))).unwrap();
-            finder.find(Some(black_box("test_file_5")))
+            finder.find(Some(black_box("test_file_5")), false) // verbose=false for benchmarks
         })
     });
 

--- a/src/bin/finder.rs
+++ b/src/bin/finder.rs
@@ -72,11 +72,11 @@ fn main() -> Result<()> {
         file_finder::Finder::new(cli.path.as_deref()).context("initializing file finder")?;
     let file_pattern = cli.file_pattern.as_deref();
 
-    // Get iterable paths
-    let paths = finder.find(file_pattern);
-
     // Determine if verbose or not
     let verbose = cli.verbose;
+
+    // Get iterable paths
+    let paths = finder.find(file_pattern, verbose);
 
     // Determine colour mode from flags and environment
     let colour_mode = ColourMode::from_env(cli.colour, cli.no_colour);

--- a/src/file_finder/mod.rs
+++ b/src/file_finder/mod.rs
@@ -14,18 +14,20 @@ impl Finder<'_> {
         Ok(Finder { path })
     }
 
-    pub fn find(&self, query: Option<&str>) -> Vec<PathBuf> {
+    pub fn find(&self, query: Option<&str>, verbose: bool) -> Vec<PathBuf> {
         // Common file metadata handling for all cases
         let file_iterator = self.find_internal().filter_map(|e| e.ok()).filter_map(|e| {
             match e.metadata() {
                 Ok(metadata) if metadata.is_file() => Some(e),
                 Ok(_) => None, // Not a file (directory, symlink, etc.)
                 Err(err) => {
-                    eprintln!(
-                        "Warning: Cannot read metadata: {} ({})",
-                        e.path().display(),
-                        err
-                    );
+                    if verbose {
+                        eprintln!(
+                            "Warning: Cannot read metadata: {} ({})",
+                            e.path().display(),
+                            err
+                        );
+                    }
                     None
                 }
             }
@@ -39,10 +41,12 @@ impl Finder<'_> {
                         Some(name) if name.contains(pattern) => Some(e),
                         Some(_) => None, // Filename doesn't match pattern
                         None => {
-                            eprintln!(
-                                "Warning: Skipping file with non-UTF8 name: {}",
-                                e.path().display()
-                            );
+                            if verbose {
+                                eprintln!(
+                                    "Warning: Skipping file with non-UTF8 name: {}",
+                                    e.path().display()
+                                );
+                            }
                             None
                         }
                     }

--- a/tests/error_handling_tests.rs
+++ b/tests/error_handling_tests.rs
@@ -7,7 +7,7 @@ use std::io::Write;
 fn test_finder_handles_valid_directory() {
     // This should not panic even if there are files it can't read
     let finder = Finder::new(Some(".")).expect("Should create finder for current directory");
-    let results = finder.find(Some("Cargo.toml"));
+    let results = finder.find(Some("Cargo.toml"), false);
 
     // Should find at least one Cargo.toml without panicking
     assert!(


### PR DESCRIPTION
## Summary

Standardize warning control by passing verbose flag through to file finder. Previously the finder always printed warnings, now they respect the user's verbose preference.

This improves API consistency - all warning messages throughout the codebase should respect the verbose flag.

## Changes

**API change (breaking):**
- `Finder::find()` signature: `find(&self, query: Option<&str>, verbose: bool)`
- All warnings (metadata errors, non-UTF8 filenames) now conditional on `verbose` flag

**Call site updates:**
- CLI: passes `cli.verbose` to finder
- Benchmarks: use `verbose=false` for clean output (2 locations)
- Tests: use `verbose=false` for clean output

## Testing

```bash
$ just pre-commit
✓ All checks passed
✓ Coverage: 89.94% (slight drop due to new conditional branches, still well above 70%)
```

## Versioning

Part of bundled release - no version bump yet. Will be included in v3.1.0 after all 3 PRs merged.

## Related

- Part of issue #55 (API design review)
- Part 1/3: #56 (merged) - Made `Finder::path` private
- Part 3/3: Coming next - Remove unused `Searches::search()` method

🤖 Generated with [Claude Code](https://claude.com/claude-code)