### PR TITLE
API: Remove unused Searches::search() method (part 3/3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - CLI passes user's verbose flag to file finder
   - Benchmarks and tests use `verbose=false` for clean output
 
+- **API cleanup:** Remove unused `Searches::search()` method
+  - Trait now only contains `search_line()` (the production code path)
+  - Removed `search()` implementations from `Searcher` and `ReSearcher`
+  - Removed helper methods `sensitive_search()` and `insensitive_search()`
+  - Updated tests to use `search_line()` directly
+  - Updated benchmarks to use line-by-line iteration
+
 ## [3.0.2] - 2026-04-21
 
 ### Changed

--- a/benches/search_benchmarks.rs
+++ b/benches/search_benchmarks.rs
@@ -54,14 +54,24 @@ fn bench_regex_searcher_search_line(c: &mut Criterion) {
 
 fn bench_searcher_search_content(c: &mut Criterion) {
     let searcher = searcher::Searcher::new("searchable", false);
-    let content = "This is line 1 with some searchable content\n\
-                   This is line 2 with more content\n\
-                   This is line 3 with searchable data\n";
+    let lines = [
+        "This is line 1 with some searchable content",
+        "This is line 2 with more content",
+        "This is line 3 with searchable data",
+    ];
 
     let mut group = c.benchmark_group("searcher_search_content");
 
     group.bench_function("search_multiline", |b| {
-        b.iter(|| searcher.search(black_box(content)))
+        b.iter(|| {
+            let mut results = Vec::new();
+            for (idx, line) in lines.iter().enumerate() {
+                if let Some(result) = searcher.search_line(black_box(line), black_box(idx + 1)) {
+                    results.push(result);
+                }
+            }
+            results
+        })
     });
 
     group.finish();

--- a/src/searcher.rs
+++ b/src/searcher.rs
@@ -21,9 +21,7 @@ pub struct ReSearcher {
 
 // Searches trait for things which can perform search functions
 pub trait Searches {
-    fn search<'a>(&'a self, contents: &'a str) -> Vec<SearchResult>;
-
-    // New method for streaming line-by-line search
+    // Line-by-line search method (used by production code)
     fn search_line(&self, line: &str, rownum: usize) -> Option<SearchResult>;
 }
 
@@ -43,20 +41,6 @@ impl Searcher<'_> {
             query,
             case_insensitive,
         }
-    }
-
-    fn sensitive_search<'a>(&'a self, contents: &'a str) -> Vec<SearchResult> {
-        let mut results = Vec::new();
-
-        for (rownum, line) in (1..).zip(contents.lines()) {
-            if line.contains(self.query) {
-                let match_positions = self.find_match_positions(line, false);
-                let result = SearchResult::new(rownum, line.to_string(), match_positions);
-                results.push(result)
-            }
-        }
-
-        results
     }
 
     fn find_match_positions(&self, line: &str, case_insensitive: bool) -> Vec<(usize, usize)> {
@@ -82,21 +66,6 @@ impl Searcher<'_> {
 
         positions
     }
-
-    fn insensitive_search<'a>(&'a self, contents: &'a str) -> Vec<SearchResult> {
-        let mut results = Vec::new();
-        let query = self.query.to_lowercase();
-
-        for (rownum, line) in (1..).zip(contents.lines()) {
-            if line.to_lowercase().contains(&query) {
-                let match_positions = self.find_match_positions(line, true);
-                let result = SearchResult::new(rownum, line.to_string(), match_positions);
-                results.push(result)
-            }
-        }
-
-        results
-    }
 }
 
 impl ReSearcher {
@@ -116,14 +85,6 @@ impl ReSearcher {
 }
 
 impl Searches for Searcher<'_> {
-    fn search<'a>(&'a self, contents: &'a str) -> Vec<SearchResult> {
-        if self.case_insensitive {
-            self.insensitive_search(contents)
-        } else {
-            self.sensitive_search(contents)
-        }
-    }
-
     fn search_line(&self, line: &str, rownum: usize) -> Option<SearchResult> {
         let matches = if self.case_insensitive {
             line.to_lowercase().contains(&self.query.to_lowercase())
@@ -141,20 +102,6 @@ impl Searches for Searcher<'_> {
 }
 
 impl Searches for ReSearcher {
-    fn search<'a>(&'a self, contents: &'a str) -> Vec<SearchResult> {
-        let mut results = Vec::new();
-
-        for (rownum, line) in (1..).zip(contents.lines()) {
-            if self.pattern.is_match(line) {
-                let match_positions = self.find_regex_match_positions(line);
-                let result = SearchResult::new(rownum, line.to_string(), match_positions);
-                results.push(result)
-            }
-        }
-
-        results
-    }
-
     fn search_line(&self, line: &str, rownum: usize) -> Option<SearchResult> {
         if self.pattern.is_match(line) {
             let match_positions = self.find_regex_match_positions(line);
@@ -169,16 +116,22 @@ impl Searches for ReSearcher {
 mod tests {
     use super::*;
     use std::io::Error;
-    static CONTENTS: &str = "line one\nLINE TWO";
 
     #[test]
     fn test_case_sensitive() -> Result<(), Error> {
         let searcher = Searcher::new("line", false);
 
-        let observed_result = searcher.search(CONTENTS);
-        let expected_result = vec![SearchResult::new(1, "line one".to_string(), vec![(0, 4)])];
+        // Test line-by-line matching (production path)
+        let result1 = searcher.search_line("line one", 1);
+        assert!(result1.is_some());
+        let unwrapped = result1.unwrap();
+        assert_eq!(unwrapped.rownum, 1);
+        assert_eq!(unwrapped.line, "line one");
+        assert_eq!(unwrapped.match_positions, vec![(0, 4)]);
 
-        assert_eq!(observed_result, expected_result);
+        // Should not match uppercase
+        let result2 = searcher.search_line("LINE TWO", 2);
+        assert!(result2.is_none());
 
         Ok(())
     }
@@ -187,13 +140,21 @@ mod tests {
     fn test_case_insensitive() -> Result<(), Error> {
         let searcher = Searcher::new("line", true);
 
-        let observed_result = searcher.search(CONTENTS);
-        let expected_result = vec![
-            SearchResult::new(1, "line one".to_string(), vec![(0, 4)]),
-            SearchResult::new(2, "LINE TWO".to_string(), vec![(0, 4)]),
-        ];
+        // Should match lowercase
+        let result1 = searcher.search_line("line one", 1);
+        assert!(result1.is_some());
+        let unwrapped1 = result1.unwrap();
+        assert_eq!(unwrapped1.rownum, 1);
+        assert_eq!(unwrapped1.line, "line one");
+        assert_eq!(unwrapped1.match_positions, vec![(0, 4)]);
 
-        assert_eq!(observed_result, expected_result);
+        // Should also match uppercase
+        let result2 = searcher.search_line("LINE TWO", 2);
+        assert!(result2.is_some());
+        let unwrapped2 = result2.unwrap();
+        assert_eq!(unwrapped2.rownum, 2);
+        assert_eq!(unwrapped2.line, "LINE TWO");
+        assert_eq!(unwrapped2.match_positions, vec![(0, 4)]);
 
         Ok(())
     }
@@ -202,14 +163,17 @@ mod tests {
     fn test_regex_match() -> Result<(), Error> {
         let re_searcher = ReSearcher::new("[a-z]+").expect("Valid regex pattern");
 
-        let observed_result = re_searcher.search(CONTENTS);
-        let expected_result = vec![SearchResult::new(
-            1,
-            "line one".to_string(),
-            vec![(0, 4), (5, 8)],
-        )];
+        // Test line-by-line matching (production path)
+        let result = re_searcher.search_line("line one", 1);
+        assert!(result.is_some());
+        let unwrapped = result.unwrap();
+        assert_eq!(unwrapped.rownum, 1);
+        assert_eq!(unwrapped.line, "line one");
+        assert_eq!(unwrapped.match_positions, vec![(0, 4), (5, 8)]);
 
-        assert_eq!(observed_result, expected_result);
+        // Should not match uppercase
+        let no_match = re_searcher.search_line("LINE TWO", 2);
+        assert!(no_match.is_none());
 
         Ok(())
     }


### PR DESCRIPTION
## Summary

Simplify the API by removing the unused `search()` method from the `Searches` trait. Production code only uses `search_line()` for streaming file processing - the `search()` method was only ever called in tests.

This reduces the API surface area and removes dead code.

## Changes

**Breaking API change:**
- `Searches` trait now only contains `search_line()` method
- Removed `search()` implementations from `Searcher` and `ReSearcher`
- Removed helper methods: `sensitive_search()` and `insensitive_search()`

**Test updates:**
- Updated tests to use `search_line()` directly
- More realistic tests (matches production usage pattern)

**Benchmark updates:**
- Changed `bench_searcher_search_content` to use line-by-line iteration
- Now benchmarks the actual production code path

## Why This Change

The `search()` method (which takes full file contents) was never used in production:
- `search_files()` uses streaming line-by-line processing via `search_line()`
- Only tests called `search()` method
- Keeping unused trait methods increases API maintenance burden

## Testing

```bash
$ just pre-commit
✓ All checks passed
✓ All tests pass using search_line()
```

## Versioning

Part of bundled release - no version bump yet. Will be included in v3.1.0 after all 3 PRs merged.

## Related

- Part of issue #55 (API design review)
- Part 1/3: #56 (merged) - Made `Finder::path` private
- Part 2/3: #100 (merged) - Added consistent `verbose` flag to `Finder::find()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)