### PR TITLE
API improvements: Remove unused parameters and add documentation

### DIFF
--- a/src/bin/finder.rs
+++ b/src/bin/finder.rs
@@ -83,7 +83,7 @@ fn main() -> Result<()> {
 
     // Create output handler based on output mode flags
     let mut output: Box<dyn Outputs> = if cli.json {
-        Box::new(JsonOutput::new(colour_mode))
+        Box::new(JsonOutput::new())
     } else if cli.files_with_matches {
         Box::new(FilesOnlyOutput::new(colour_mode))
     } else if cli.count {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@ const CHUNK_SIZE: usize = 8192; // 8KB chunks for reading files
 
 pub fn search_files(
     searcher: impl searcher::Searches,
-    paths: Vec<PathBuf>,
+    paths: impl IntoIterator<Item = PathBuf>,
     verbose: bool,
     output: &mut dyn output::Outputs,
 ) -> Result<()> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,12 @@ pub use output::{
 };
 pub use searcher::{ReSearcher, SearchResult, Searcher, Searches};
 
-const CHUNK_SIZE: usize = 8192; // 8KB chunks for reading files
+/// Buffer size for reading files (8KB)
+///
+/// This size is chosen as a balance between memory usage and I/O efficiency.
+/// The BufReader uses this capacity to minimize system calls while keeping
+/// memory footprint reasonable for processing many files.
+const CHUNK_SIZE: usize = 8192;
 
 pub fn search_files(
     searcher: impl searcher::Searches,

--- a/src/output/json.rs
+++ b/src/output/json.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::path::Path;
 
-use super::{ColourMode, Outputs, SearchMatch};
+use super::{Outputs, SearchMatch};
 
 /// JSON match representation
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -25,8 +25,7 @@ pub struct JsonOutput {
 }
 
 impl JsonOutput {
-    pub fn new(_colour_mode: ColourMode) -> Self {
-        // JSON output never uses colours
+    pub fn new() -> Self {
         JsonOutput {
             files: HashMap::new(),
         }
@@ -35,7 +34,7 @@ impl JsonOutput {
 
 impl Default for JsonOutput {
     fn default() -> Self {
-        Self::new(ColourMode::Never)
+        Self::new()
     }
 }
 
@@ -120,7 +119,7 @@ mod tests {
 
     #[test]
     fn test_json_output_accumulates_matches() {
-        let mut output = JsonOutput::new(ColourMode::Never);
+        let mut output = JsonOutput::new();
         let path = PathBuf::from("test.txt");
 
         // Add multiple matches from same file
@@ -145,7 +144,7 @@ mod tests {
 
     #[test]
     fn test_json_output_write_file() {
-        let mut output = JsonOutput::new(ColourMode::Never);
+        let mut output = JsonOutput::new();
         let path = PathBuf::from("empty.txt");
 
         // Add file with no matches


### PR DESCRIPTION
## Summary

Three small API improvements identified in the API review:

1. **Remove ColourMode from JsonOutput** - Breaking but trivial
2. **Accept iterator in search_files()** - Non-breaking improvement
3. **Document CHUNK_SIZE** - Documentation improvement

All are low-effort, high-impact changes that improve API quality.

## Changes

### Commit 1: Remove unused ColourMode parameter from JsonOutput

**Breaking change:**
- `JsonOutput::new()` no longer takes ColourMode parameter
- JsonOutput never used colours (it's plain JSON)

**Migration:**
```rust
// Before
JsonOutput::new(colour_mode)

// After
JsonOutput::new()
```

### Commit 2: Accept iterator in search_files()

**Non-breaking change:**
- Changed `paths: Vec<PathBuf>` to `paths: impl IntoIterator<Item = PathBuf>`
- Vec implements IntoIterator, so existing code works unchanged
- More flexible and idiomatic Rust

**Benefits:**
- Callers can pass any iterable collection
- No forced allocation if caller has different collection type
- More composable with iterator chains

### Commit 3: Document CHUNK_SIZE constant

**Documentation improvement:**
- Added doc comment explaining why 8KB was chosen
- Explains trade-off between memory and I/O efficiency
- Helps future maintainers understand the decision

## Testing

```bash
$ just pre-commit
✓ All tests pass
✓ All clippy checks pass
✓ Formatting correct
```

## Versioning

These changes will be part of v3.1.0:
- Breaking change to JsonOutput (minor bump justified)
- Part of bundled API improvements from issue #55

## Related Issues

- Part of #55 (API design review)
- Created #102 (Add find_iter() - medium effort)
- Created #103 (Builder pattern - low priority, deferred)

🤖 Generated with [Claude Code](https://claude.com/claude-code)