### PR TITLE
Rename PAT_TOKEN to ACTIONS_TOKEN for clarity

### DIFF
--- a/.github/workflows/comparison.yml
+++ b/.github/workflows/comparison.yml
@@ -234,7 +234,7 @@ jobs:
       - name: Create Pull Request
         if: env.skip_pr == 'false'
         env:
-          GH_TOKEN: ${{ secrets.PAT_TOKEN }}
+          GH_TOKEN: ${{ secrets.ACTIONS_TOKEN }}
         run: |
           gh pr create \
             --base main \

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -155,9 +155,9 @@ jobs:
 
           git tag -a "$TAG_NAME" -m "Release $TAG_NAME"
 
-          # Push using PAT to trigger release workflow
-          # Using PAT_TOKEN instead of GITHUB_TOKEN to trigger downstream workflows
-          git push https://x-access-token:${{ secrets.PAT_TOKEN }}@github.com/${{ github.repository }}.git "$TAG_NAME"
+          # Push using Actions token to trigger release workflow
+          # Using ACTIONS_TOKEN instead of GITHUB_TOKEN to trigger downstream workflows
+          git push https://x-access-token:${{ secrets.ACTIONS_TOKEN }}@github.com/${{ github.repository }}.git "$TAG_NAME"
 
           echo "✅ Created and pushed tag $TAG_NAME"
           echo "tag=$TAG_NAME" >> $GITHUB_OUTPUT
@@ -166,7 +166,7 @@ jobs:
         if: steps.tag-check.outputs.exists == 'false'
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.PAT_TOKEN }}
+          github-token: ${{ secrets.ACTIONS_TOKEN }}
           script: |
             // Trigger the release workflow manually as a fallback
             // PATs from the same account don't always trigger workflows on tag push


### PR DESCRIPTION
## Summary

Rename the GitHub secret from `PAT_TOKEN` to `ACTIONS_TOKEN` to better reflect its purpose.

## Motivation

`PAT_TOKEN` is vague - "Personal Access Token token" is redundant and doesn't explain what the token is for. `ACTIONS_TOKEN` clearly indicates it's used to trigger GitHub Actions workflows.

## Changes

Updated references in:
- `.github/workflows/main.yml` - Auto-tag workflow (2 locations)
- `.github/workflows/comparison.yml` - PR creation (1 location)

**No version changes or other files modified** - this PR only touches workflow files.

## Action Required

**You must rename the GitHub secret before merging:**

1. Go to **Settings > Secrets and variables > Actions**
2. Either:
   - Rename `PAT_TOKEN` to `ACTIONS_TOKEN`, or
   - Create new `ACTIONS_TOKEN` secret (same value), then delete `PAT_TOKEN`

## Token Requirements (Unchanged)

The token permissions remain the same:

**Fine-grained token (recommended):**
- Repository: ydkadri/finders
- Permissions:
  - Contents: Read and write
  - Actions: Read and write

**Classic token (alternative):**
- Scopes: `repo` + `workflow`

## Testing

After renaming the secret, the next merge to main will test:
1. Auto-tag creation on version bump
2. Release workflow trigger
3. Benchmark PR creation

🤖 Generated with [Claude Code](https://claude.com/claude-code)