### PR TITLE
Add hotfix release guidance to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -385,6 +385,46 @@ git push origin vX.Y.Z
 4. Create GitHub release with binaries and notes
 5. Benchmark workflow runs and creates PR with updated results
 
+### Hotfixes for Old Releases
+
+If you need to patch a previously released version (e.g., critical bug in production while main has moved ahead):
+
+**Step 1: Create hotfix branch from old tag**
+```bash
+git fetch --tags
+git checkout v3.0.0              # Checkout the old release tag
+git checkout -b release/v3.0.1   # Create hotfix branch
+```
+
+**Step 2: Make fixes and commit**
+```bash
+# Make your fixes
+git add .
+git commit -m "Fix critical security issue in v3.0.x"
+
+# Update version in Cargo.toml and CHANGELOG
+# Commit: "Release v3.0.1 - Security hotfix"
+```
+
+**Step 3: Push branch and tag**
+```bash
+git push -u origin release/v3.0.1
+git tag -a v3.0.1 -m "Release v3.0.1"
+git push origin v3.0.1            # Triggers release workflow
+```
+
+**Step 4: Consider backporting to main**
+```bash
+git checkout main
+git cherry-pick <commit-hash>     # Cherry-pick the fix if applicable
+```
+
+**Notes:**
+- Tags point to commits, not branches - release workflow works regardless of branch
+- Hotfix branches are kept for historical reference
+- Always tag the release branch commit, not main
+- Consider if the fix should also be applied to main
+
 ---
 
 ## Quick Reference


### PR DESCRIPTION
## Summary

Documents the process for creating hotfix releases when you need to patch an older version while main has moved ahead.

## Why This is Needed

Without this guidance, it's unclear how to handle scenarios like:
- Critical security fix needed for v3.0.0
- But main is already at v3.2.0 with breaking changes
- Can't release the fix as v3.3.0 (wrong semantic version)
- Need to release as v3.0.1 but from a separate branch

## What's Documented

**New section: "Hotfixes for Old Releases"**

Covers:
1. Creating hotfix branch from old tag
2. Making and committing fixes
3. Pushing branch and creating tag
4. Cherry-picking fixes back to main if applicable

**Key points:**
- Tags point to commits, not branches - release workflow works anywhere
- Hotfix branches are kept for historical reference  
- Semantic versioning is preserved (v3.0.0 → v3.0.1)
- Guidance on when/how to backport to main

## Example Workflow

```bash
# Patch v3.0.0 with security fix
git checkout v3.0.0
git checkout -b release/v3.0.1
# Make fixes, update version
git commit -m "Release v3.0.1 - Security hotfix"
git push -u origin release/v3.0.1
git tag -a v3.0.1 -m "Release v3.0.1"
git push origin v3.0.1  # Triggers release
```

## Related

Complements the existing "Release Process" documentation that covers normal releases from main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)