### PR TITLE
Fix outdated documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,6 +14,7 @@ I'm still learning the Rust language, so if you're proposing changes, please exp
 
 - Rust (stable) - [Install from rustup.rs](https://rustup.rs/)
 - Git
+- [just](https://github.com/casey/just) - Command runner (optional but recommended)
 
 ### Setup
 
@@ -22,15 +23,19 @@ I'm still learning the Rust language, so if you're proposing changes, please exp
 git clone https://github.com/ydkadri/finders.git
 cd finders
 
-# Build and run
+# Build and run (using just - matches CI)
+just build
+just run . -s "TODO"
+
+# Or use cargo directly
 cargo build
 cargo run -- . -s "TODO"
 
-# Run tests
-cargo test
+# Run tests (using just ensures same config as CI)
+just test
 
 # Run benchmarks
-cargo bench
+just bench
 ```
 
 ## How to Contribute
@@ -58,7 +63,7 @@ When suggesting features:
 
 **PR Guidelines:**
 1. Write tests for new functionality
-2. Ensure all CI checks pass (`cargo fmt`, `cargo clippy`, `cargo test`)
+2. Ensure all CI checks pass (use `just pre-commit` to run same checks as CI)
 3. Keep commits focused and logical
 4. Write clear commit messages explaining **why**, not just what
 
@@ -66,9 +71,10 @@ When suggesting features:
 
 ### Style
 
-- Run `cargo fmt` before committing
-- Run `cargo clippy -- -D warnings` and fix all warnings
+- Run `just fmt` before committing (or `cargo fmt` directly)
+- Run `just lint` and fix all warnings (or `cargo clippy -- -D warnings` directly)
 - Follow Rust naming conventions (see [CLAUDE.md](CLAUDE.md) for details)
+- Use `just` commands when possible to ensure consistency with CI
 
 ### Testing
 

--- a/README.md
+++ b/README.md
@@ -305,36 +305,6 @@ Benchmarks run automatically on new releases and can be triggered manually via G
 
 ---
 
-## Development
-
-### Running Tests and Benchmarks
-
-To run internal benchmarks locally:
-```shell
-cargo bench
-```
-
-To run comparison benchmarks (requires `ripgrep` installed):
-```shell
-cargo build --release  # Build finder first
-cargo bench --bench comparison_benchmarks
-```
-
-To run tests:
-```shell
-cargo test
-```
-
-### Code Quality
-
-To check code quality:
-```shell
-cargo fmt --all -- --check
-cargo clippy -- -D warnings
-```
-
----
-
 ## Contributing
 
 Contributions are welcome! Please read [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
@@ -348,14 +318,17 @@ Key points:
 
 ## Release Process
 
-Releases are automated through GitHub Actions:
-1. Update version in `Cargo.toml`
-2. Update `CHANGELOG.md`
-3. Merge to main - the auto-tag workflow creates a git tag
+Releases are semi-automated through GitHub Actions:
+1. Update version in `Cargo.toml` and `CHANGELOG.md`
+2. Merge version bump PR to main
+3. Manually create and push git tag: `git tag -a vX.Y.Z -m "Release vX.Y.Z" && git push origin vX.Y.Z`
 4. The release workflow automatically:
    - Builds binaries for all platforms
-   - Creates a GitHub release
+   - Creates a GitHub release with binaries
    - Publishes to crates.io
+   - Triggers benchmark workflow with updated results
+
+See [CLAUDE.md](CLAUDE.md) for detailed release process including hotfix procedures.
 
 ---
 


### PR DESCRIPTION
## Summary
- Remove duplicate Development section from README.md
- Update Release Process section to reflect manual tagging (auto-tag workflow was removed)
- Update CONTRIBUTING.md to recommend `just` commands for CI consistency

## Changes

### README.md
- ❌ Remove duplicate Development section with old cargo commands
- ✅ Update Release Process to reflect manual git tagging
- ✅ Add reference to CLAUDE.md for detailed procedures

### CONTRIBUTING.md
- ✅ Add `just` as recommended prerequisite
- ✅ Update setup examples to show both `just` and `cargo` commands
- ✅ Recommend `just` commands for CI consistency
- ✅ Update PR guidelines to reference `just pre-commit`

## Why
Contributors should use the same commands as CI to avoid surprises. The auto-tag workflow was removed in 9de39f0, but README still referenced it.

## Test plan
- [x] Documentation-only changes, no code modified
- [ ] CI passes (validate formatting)

🤖 Generated with [Claude Code](https://claude.com/claude-code)