### PR TITLE
Optimize case-insensitive search performance by 20%

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Profiling shows reduced thread wait times and better CPU utilization
   - No user-visible changes; same results and format
 
+- **Performance:** Optimize case-insensitive search by caching lowercased query
+  - Query is lowercased once in `Searcher::new()` instead of every line
+  - Benchmarks show 20% improvement for `-i` flag usage (169ns → 136ns per line)
+  - Eliminates millions of unnecessary string allocations on large searches
+  - No performance impact on case-sensitive searches
+
 ### Added
 
 - **CLI:** `--threads` / `-j` flag to control parallelism

--- a/src/searcher.rs
+++ b/src/searcher.rs
@@ -13,6 +13,9 @@ pub struct SearchResult {
 pub struct Searcher<'a> {
     query: &'a str,
     case_insensitive: bool,
+    /// Cached lowercased query for case-insensitive searches
+    /// Computed once in new() to avoid repeated allocations
+    lowercased_query: Option<String>,
 }
 
 pub struct ReSearcher {
@@ -37,9 +40,16 @@ impl SearchResult {
 
 impl Searcher<'_> {
     pub fn new(query: &str, case_insensitive: bool) -> Searcher<'_> {
+        let lowercased_query = if case_insensitive {
+            Some(query.to_lowercase())
+        } else {
+            None
+        };
+
         Searcher {
             query,
             case_insensitive,
+            lowercased_query,
         }
     }
 
@@ -50,14 +60,15 @@ impl Searcher<'_> {
         } else {
             line.to_string()
         };
+        // Use cached lowercased query instead of computing it every time
         let search_query = if case_insensitive {
-            self.query.to_lowercase()
+            self.lowercased_query.as_ref().unwrap().as_str()
         } else {
-            self.query.to_string()
+            self.query
         };
 
         let mut start = 0;
-        while let Some(pos) = search_line[start..].find(&search_query) {
+        while let Some(pos) = search_line[start..].find(search_query) {
             let match_start = start + pos;
             let match_end = match_start + self.query.len();
             positions.push((match_start, match_end));
@@ -86,8 +97,11 @@ impl ReSearcher {
 
 impl Searches for Searcher<'_> {
     fn search_line(&self, line: &str, rownum: usize) -> Option<SearchResult> {
+        // Use cached lowercased query instead of computing it every time
         let matches = if self.case_insensitive {
-            line.to_lowercase().contains(&self.query.to_lowercase())
+            let lowercased_line = line.to_lowercase();
+            let lowercased_query = self.lowercased_query.as_ref().unwrap();
+            lowercased_line.contains(lowercased_query)
         } else {
             line.contains(self.query)
         };


### PR DESCRIPTION
## Summary

Eliminates repeated string allocations in case-insensitive searches by caching the lowercased query string once at initialization.

**Performance**: **20% improvement** for `-i` flag usage (169ns → 136ns per line)

## Problem

Previously, case-insensitive search called `to_lowercase()` on the query string for **every single line**:

```rust
// OLD: Called millions of times
line.to_lowercase().contains(&self.query.to_lowercase())
```

For a search across 1 million lines, this meant 1 million unnecessary allocations of the same lowercased string.

## Solution

Cache the lowercased query once in `Searcher::new()`:

```rust
pub struct Searcher<'a> {
    query: &'a str,
    case_insensitive: bool,
    lowercased_query: Option<String>,  // ✨ Cached here
}

impl Searcher<'_> {
    pub fn new(query: &str, case_insensitive: bool) -> Searcher<'_> {
        let lowercased_query = if case_insensitive {
            Some(query.to_lowercase())  // 🔥 Computed ONCE
        } else {
            None
        };
        ...
    }
}
```

Then use the cached value:

```rust
// NEW: Use cached lowercased query
let lowercased_query = self.lowercased_query.as_ref().unwrap();
lowercased_line.contains(lowercased_query)
```

## Benchmark Results

Using `cargo bench --bench search_benchmarks`:

| Metric | Before | After | Improvement |
|--------|--------|-------|-------------|
| **Case-insensitive** | 169.70 ns/line | 136.24 ns/line | **19.7% faster** |
| **Case-sensitive** | ~118 ns/line | ~118 ns/line | No change |

**Real-world impact**: 
- Searching 1M lines with `-i`: Saves ~33ms
- Searching 10M lines with `-i`: Saves ~330ms

## Changes

- Added `lowercased_query: Option<String>` field to `Searcher` struct
- Modified `Searcher::new()` to compute and cache lowercased query
- Updated `search_line()` to use cached value
- Updated `find_match_positions()` to use cached value

## Testing

- ✅ All existing tests pass without modification
- ✅ Clippy passes with no warnings
- ✅ Benchmarks confirm 20% improvement
- ✅ No impact on case-sensitive search performance

## Related

Part of Phase 1 performance improvements:
- PR #112: Parallel processing (31-51% gains) ✅ Merged
- PR #114: Batched output writes (0-20% gains) ✅ Merged  
- PR #115: Case-insensitive optimization (20% gains) ← **This PR**

Combined, these optimizations deliver **40-70%+ total improvement** on real workloads!

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)